### PR TITLE
Various improvements to CLI

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(Modle::common ALIAS modle_common)
 target_sources(
   modle_common
   INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/modle/common/common.hpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/include/modle/common/const_map.hpp
             ${CMAKE_CURRENT_SOURCE_DIR}/include/modle/common/simulation_config.hpp
             ${CMAKE_CURRENT_SOURCE_DIR}/include/modle/common/genextreme_value_distribution.hpp
             ${CMAKE_CURRENT_SOURCE_DIR}/include/modle/common/random.hpp

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -4,6 +4,7 @@
 
 find_package(absl CONFIG REQUIRED)
 find_package(Boost CONFIG REQUIRED)
+find_package(CLI11 CONFIG REQUIRED)
 find_package(fmt CONFIG REQUIRED)
 find_package(range-v3 CONFIG REQUIRED)
 find_package(xxHash CONFIG REQUIRED)
@@ -34,6 +35,7 @@ target_link_system_libraries(
   Boost::headers
   Boost::filesystem
   Boost::random
+  CLI11::CLI11
   fmt::fmt
   range-v3::range-v3
   $<$<NOT:$<BOOL:${MODLE_USE_MERSENNE_TWISTER}>>:XoshiroCpp::XoshiroCpp>

--- a/src/common/cli_utils_impl.hpp
+++ b/src/common/cli_utils_impl.hpp
@@ -241,7 +241,7 @@ std::string Formatter::make_option_opts(const CLI::Option *opt) const {
     }
 
     if (opt->get_required()) {
-      out += " required";
+      out += " REQUIRED";
     }
   }
   if (!opt->get_envname().empty()) {
@@ -260,7 +260,7 @@ std::string Formatter::make_option_opts(const CLI::Option *opt) const {
     }
   }
 
-  return absl::AsciiStrToLower(out);
+  return out;
 }
 
 }  // namespace modle::utils

--- a/src/common/const_map_impl.hpp
+++ b/src/common/const_map_impl.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <array>
+#include <initializer_list>
+#include <stdexcept>
+#include <utility>
+
+#include "modle/common/common.hpp"
+
+namespace modle::utils {
+template <class Key, class Value, usize Size>
+constexpr ConstMap<Key, Value, Size>::ConstMap(
+    const std::initializer_list<std::pair<Key, Value>> &args) {
+  if (args.size() < Size) {
+    throw std::logic_error("Not enough arguments to initialize ConstMap");
+  }
+  if (args.size() > Size) {
+    throw std::out_of_range("Too many arguments to initialize ConstMap");
+  }
+
+  usize i = 0;
+  for (const auto &[k, v] : args) {
+    _keys[i] = k;
+    _vals[i] = v;
+    ++i;
+  }
+
+  this->detect_duplicate_keys();
+}
+
+template <class Key, class Value, usize Size>
+template <class KeyInputIt, class ValueInputIt>
+constexpr ConstMap<Key, Value, Size>::ConstMap(KeyInputIt first_key, KeyInputIt last_key,
+                                               ValueInputIt first_value) {
+  const auto dist = static_cast<usize>(std::distance(first_key, last_key));
+  if (dist < Size) {
+    throw std::logic_error("Not enough values to initialize ConstMap");
+  }
+  if (dist > Size) {
+    throw std::out_of_range("Too many values to initialize ConstMap");
+  }
+
+  std::move(first_key, last_key, this->_keys.begin());
+  std::move(first_value, first_value + static_cast<isize>(dist), this->_vals.begin());
+
+  this->detect_duplicate_keys();
+}
+
+template <class Key, class Value, usize Size>
+constexpr void ConstMap<Key, Value, Size>::detect_duplicate_keys() const {
+  if constexpr (utils::ndebug_not_defined()) {
+    for (const auto &k : _keys) {
+      usize i = 0;
+      for (const auto &kk : _keys) {
+        i += k == kk;
+      }
+      if (i != 1) {
+        throw std::logic_error("Detected a duplicate key");
+      }
+    }
+  }
+}
+
+template <class Key, class Value, usize Size>
+constexpr bool ConstMap<Key, Value, Size>::empty() const noexcept {
+  return this->_keys.empty();
+}
+
+template <class Key, class Value, usize Size>
+constexpr usize ConstMap<Key, Value, Size>::size() const noexcept {
+  return this->_keys.size();
+}
+
+template <class Key, class Value, usize Size>
+constexpr const Value &ConstMap<Key, Value, Size>::at(const Key &key) const {
+  const auto itr = this->find(key);
+  if (itr != this->end()) {
+    assert(itr.second);
+    return *itr.second;
+  }
+  throw std::range_error(fmt::format(FMT_STRING("Unable to find key \"{}\""), key));
+}
+
+template <class Key, class Value, usize Size>
+constexpr const Value &ConstMap<Key, Value, Size>::operator[](const Key &key) const {
+  return *this->find(key)->second;
+}
+
+template <class Key, class Value, usize Size>
+constexpr auto ConstMap<Key, Value, Size>::find(const Key &key) const noexcept -> const_iterator {
+  auto it = std::find(this->_keys.begin(), this->_keys.end(), key);
+  return iterator(*this, static_cast<usize>(std::distance(this->_keys.begin(), it)));
+}
+
+template <class Key, class Value, usize Size>
+constexpr bool ConstMap<Key, Value, Size>::contains(const Key &key) const noexcept {
+  return this->find(key) != this->end();
+}
+
+template <class Key, class Value, usize Size>
+constexpr auto ConstMap<Key, Value, Size>::begin() const noexcept -> const_iterator {
+  return iterator(*this, 0);
+}
+
+template <class Key, class Value, usize Size>
+constexpr auto ConstMap<Key, Value, Size>::end() const noexcept -> const_iterator {
+  return iterator(*this, this->size());
+}
+
+template <class Key, class Value, usize Size>
+constexpr const std::array<Key, Size> &ConstMap<Key, Value, Size>::keys() const noexcept {
+  return this->_keys;
+}
+
+template <class Key, class Value, usize Size>
+constexpr const std::array<Value, Size> &ConstMap<Key, Value, Size>::values() const noexcept {
+  return this->_vals;
+}
+
+template <class Key, class Value, usize Size>
+constexpr ConstMap<Key, Value, Size>::iterator::iterator(const ConstMap<Key, Value, Size> &map,
+                                                         usize i) noexcept
+    : first(map._keys.data() + i), second(map._vals.data() + i) {}
+
+template <class Key, class Value, usize Size>
+constexpr bool ConstMap<Key, Value, Size>::iterator::operator==(
+    const ConstMap<Key, Value, Size>::iterator &other) const noexcept {
+  return this->first == other.first;
+}
+
+template <class Key, class Value, usize Size>
+constexpr bool ConstMap<Key, Value, Size>::iterator::operator!=(
+    const ConstMap<Key, Value, Size>::iterator &other) const noexcept {
+  return !(*this == other);
+}
+
+template <class Key, class Value, usize Size>
+constexpr auto ConstMap<Key, Value, Size>::iterator::operator*() const -> const value_type {
+  assert(this->first);
+  assert(this->second);
+  return std::make_pair(this->first, this->second);
+}
+
+template <class Key, class Value, usize Size>
+constexpr auto ConstMap<Key, Value, Size>::iterator::operator++() noexcept -> iterator & {
+  assert(this->first);
+  assert(this->second);
+  ++this->first;
+  ++this->second;
+  return *this;
+}
+
+template <class Key, class Value, usize Size>
+constexpr auto ConstMap<Key, Value, Size>::iterator::operator++(int) const noexcept -> iterator {
+  auto it = *this;
+  std::ignore = ++it;
+  return it;
+}
+}  // namespace modle::utils

--- a/src/common/include/modle/common/cli_utils.hpp
+++ b/src/common/include/modle/common/cli_utils.hpp
@@ -6,6 +6,7 @@
 
 #include <absl/container/fixed_array.h>
 
+#include <CLI/Formatter.hpp>
 #include <boost/filesystem/file_status.hpp>  // for regular_file, file_type
 #include <boost/filesystem/path.hpp>         // for path
 #include <initializer_list>
@@ -74,6 +75,10 @@ class CliEnumMappings {
 
   [[nodiscard]] inline auto keys_view() const -> decltype(ranges::views::keys(this->_mappings));
   [[nodiscard]] inline auto values_view() const -> decltype(ranges::views::values(this->_mappings));
+};
+
+class Formatter : public CLI::Formatter {
+  [[nodiscard]] inline std::string make_option_opts(const CLI::Option* opt) const override;
 };
 
 }  // namespace modle::utils

--- a/src/common/include/modle/common/cli_utils.hpp
+++ b/src/common/include/modle/common/cli_utils.hpp
@@ -14,6 +14,9 @@
 #include <string>       // for string
 #include <string_view>  // for string_view
 
+#include "modle/common/common.hpp"
+#include "modle/common/const_map.hpp"
+
 namespace modle::utils {
 
 // Try to convert str representations like "1.0" or "1.000000" to "1"

--- a/src/common/include/modle/common/cli_utils.hpp
+++ b/src/common/include/modle/common/cli_utils.hpp
@@ -17,16 +17,18 @@
 namespace modle::utils {
 
 // Try to convert str representations like "1.0" or "1.000000" to "1"
-[[nodiscard]] inline std::string str_float_to_str_int(const std::string& s);
+[[nodiscard]] inline std::string trim_trailing_zeros_from_decimal_digits(std::string&& s);
 
-[[nodiscard]] inline std::string replace_non_alpha_char(const std::string& s, char replacement);
 template <char replacement = '_'>
-[[nodiscard]] inline std::string replace_non_alpha_char(const std::string& s);
+[[nodiscard]] inline std::string replace_non_alpha_char(std::string&& s);
 
 template <class Collection>
 [[nodiscard]] inline std::string format_collection_to_english_list(const Collection& collection,
                                                                    std::string_view sep = ", ",
                                                                    std::string_view last_sep = "");
+
+template <class N = double>
+[[nodiscard]] inline bool is_finite_number(const std::string& s);
 
 // Returns false in case a collision was detected
 inline bool detect_path_collision(
@@ -77,9 +79,16 @@ class CliEnumMappings {
   [[nodiscard]] inline auto values_view() const -> decltype(ranges::views::values(this->_mappings));
 };
 
+namespace cli {
 class Formatter : public CLI::Formatter {
   [[nodiscard]] inline std::string make_option_opts(const CLI::Option* opt) const override;
 };
+
+struct IsFinite : public CLI::Validator {
+  [[nodiscard]] inline IsFinite(bool nan_ok = false);
+};
+
+}  // namespace cli
 
 }  // namespace modle::utils
 

--- a/src/common/include/modle/common/cli_utils.hpp
+++ b/src/common/include/modle/common/cli_utils.hpp
@@ -20,10 +20,10 @@
 namespace modle::utils {
 
 // Try to convert str representations like "1.0" or "1.000000" to "1"
-[[nodiscard]] inline std::string trim_trailing_zeros_from_decimal_digits(std::string&& s);
+[[nodiscard]] inline std::string trim_trailing_zeros_from_decimal_digits(std::string& s);
 
 template <char replacement = '_'>
-[[nodiscard]] inline std::string replace_non_alpha_char(std::string&& s);
+[[nodiscard]] inline std::string replace_non_alpha_char(std::string& s);
 
 template <class Collection>
 [[nodiscard]] inline std::string format_collection_to_english_list(const Collection& collection,
@@ -87,9 +87,33 @@ class Formatter : public CLI::Formatter {
   [[nodiscard]] inline std::string make_option_opts(const CLI::Option* opt) const override;
 };
 
-struct IsFinite : public CLI::Validator {
-  [[nodiscard]] inline IsFinite(bool nan_ok = false);
+static constexpr ConstMap<std::string_view, bp_t, 10> genomic_distance_unit_multiplier_map{
+    {"bp", bp_t(1)},
+    {"k", bp_t(1'000)},
+    {"kb", bp_t(1'000)},
+    {"kbp", bp_t(1'000)},
+    {"m", bp_t(1'000'000)},
+    {"mb", bp_t(1'000'000)},
+    {"mbp", bp_t(1'000'000)},
+    {"g", bp_t(1'000'000'000)},
+    {"gb", bp_t(1'000'000'000)},
+    {"gbp", bp_t(1'000'000'000)}};
+
+struct IsFiniteValidator : public CLI::Validator {
+  inline explicit IsFiniteValidator(bool nan_ok = false);
 };
+
+struct TrimTrailingZerosFromDecimalDigitValidator : public CLI::Transformer {
+  inline TrimTrailingZerosFromDecimalDigitValidator();
+};
+
+struct AsGenomicDistanceTransformer : public CLI::CheckedTransformer {
+  inline AsGenomicDistanceTransformer();
+};
+
+inline const auto IsFinite = IsFiniteValidator();
+inline const auto TrimTrailingZerosFromDecimalDigit = TrimTrailingZerosFromDecimalDigitValidator();
+inline const auto AsGenomicDistance = AsGenomicDistanceTransformer();
 
 }  // namespace cli
 

--- a/src/common/include/modle/common/common.hpp
+++ b/src/common/include/modle/common/common.hpp
@@ -11,6 +11,19 @@
 #include <cstdint>  // for i8, i16, i32, i64, u8 ...
 
 namespace modle {
+namespace utils {
+[[maybe_unused]] [[nodiscard]] constexpr bool ndebug_defined() noexcept {
+#ifdef NDEBUG
+  return true;
+#else
+  return false;
+#endif
+}
+
+[[maybe_unused]] [[nodiscard]] constexpr bool ndebug_not_defined() noexcept {
+  return !ndebug_defined();
+}
+};  // namespace utils
 
 // Define short aliases for common integral types
 using u8 = std::uint8_t;

--- a/src/common/include/modle/common/const_map.hpp
+++ b/src/common/include/modle/common/const_map.hpp
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <array>
+#include <initializer_list>
+#include <utility>
+
+#include "modle/common/common.hpp"
+
+namespace modle::utils {
+// Source: https://www.youtube.com/watch?v=INn3xa4pMfg
+template <class Key, class Value, usize Size>
+class ConstMap {
+  // std::array<std::pair<Key, Value>, Size> _buff{};
+  std::array<Key, Size> _keys{};
+  std::array<Value, Size> _vals{};
+
+ public:
+  // NOLINTNEXTLINE(hicpp-explicit-conversions)
+  constexpr ConstMap(const std::initializer_list<std::pair<Key, Value>>& args);
+
+  template <class KeyInputIt, class ValueInputIt>
+  constexpr ConstMap(KeyInputIt first_key, KeyInputIt last_key, ValueInputIt first_value);
+
+  class iterator;
+  using const_iterator = const iterator;
+  using key_type = Key;
+  using mapped_type = Value;
+  using value_type = std::pair<const Key, Value>;
+  using first_type = const Key;
+  using second_type = Value;
+
+  [[nodiscard]] constexpr bool empty() const noexcept;
+  [[nodiscard]] constexpr usize size() const noexcept;
+
+  [[nodiscard]] constexpr const Value& at(const Key& key) const;
+  [[nodiscard]] constexpr const Value& operator[](const Key& key) const;
+  [[nodiscard]] constexpr auto find(const Key& key) const noexcept -> const_iterator;
+  [[nodiscard]] constexpr bool contains(const Key& key) const noexcept;
+
+  [[nodiscard]] constexpr auto begin() const noexcept -> const_iterator;
+  [[nodiscard]] constexpr auto end() const noexcept -> const_iterator;
+
+  [[nodiscard]] constexpr const std::array<Key, Size>& keys() const noexcept;
+  [[nodiscard]] constexpr const std::array<Value, Size>& values() const noexcept;
+
+  class iterator {
+    friend ConstMap;
+
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
+    constexpr iterator(const ConstMap& map, usize i = 0) noexcept;
+
+   public:
+    constexpr iterator() = delete;
+    using value_type = std::pair<const Key, Value>;
+    using difference_type = isize;
+    using pointer = value_type*;
+    using reference = value_type&;
+    using iterator_category = std::input_iterator_tag;
+
+    const Key* first;     // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+    const Value* second;  // NOLINT(cppcoreguidelines-non-private-member-variables-in-classes)
+
+    [[nodiscard]] constexpr auto operator*() const -> const value_type;
+    constexpr bool operator==(const iterator& other) const noexcept;
+    constexpr bool operator!=(const iterator& other) const noexcept;
+
+    constexpr auto operator++() noexcept -> iterator&;
+    constexpr auto operator++(int) const noexcept -> iterator;
+  };
+
+ private:
+  constexpr void detect_duplicate_keys() const;
+};
+}  // namespace modle::utils
+
+#include "../../../const_map_impl.hpp"

--- a/src/common/include/modle/common/random.hpp
+++ b/src/common/include/modle/common/random.hpp
@@ -8,7 +8,6 @@
 #include <type_traits>  // for result_of
 
 #include "modle/common/common.hpp"  // for u64
-#include "modle/common/utils.hpp"   // for ndebug_defined
 
 #if !defined(MODLE_USE_MERSENNE_TWISTER)
 #define USE_XOSHIRO

--- a/src/common/include/modle/common/simulation_config.hpp
+++ b/src/common/include/modle/common/simulation_config.hpp
@@ -47,7 +47,6 @@ struct Config {
   bool force{false};
   bool quiet{false};
   bool write_contacts_for_ko_chroms{false};
-  bool write_tasks_to_disk{true};
   boost::filesystem::path path_to_reference_contacts{};
   std::vector<boost::filesystem::path> path_to_feature_bed_files{};
   boost::filesystem::path path_to_output_file_bedpe{};
@@ -75,7 +74,6 @@ struct Config {
   double genextreme_mu{0};
   double genextreme_sigma{5'000};
   double genextreme_xi{0.001};
-  bool exclude_chrom_wo_extr_barriers{true};
 
   // LEFs params
   bp_t fwd_extrusion_speed{bin_size / 2};

--- a/src/common/include/modle/common/simulation_config.hpp
+++ b/src/common/include/modle/common/simulation_config.hpp
@@ -46,7 +46,6 @@ struct Config {
   boost::filesystem::path path_to_extr_barriers;
   bool force{false};
   bool quiet{false};
-  bool write_contacts_for_ko_chroms{false};
   boost::filesystem::path path_to_reference_contacts{};
   std::vector<boost::filesystem::path> path_to_feature_bed_files{};
   boost::filesystem::path path_to_output_file_bedpe{};
@@ -99,6 +98,7 @@ struct Config {
   double lef_bar_minor_collision_pblock{0.0};
 
   // Miscellaneous
+  bool simulate_chromosomes_wo_barriers{false};
   usize num_cells{512};
   usize nthreads{std::thread::hardware_concurrency()};
   u64 seed{0};
@@ -117,6 +117,11 @@ struct Config {
   double burnin_speed_coefficient{1.0};
   bp_t fwd_extrusion_speed_burnin{bp_t(double(fwd_extrusion_speed) * burnin_speed_coefficient)};
   bp_t rev_extrusion_speed_burnin{fwd_extrusion_speed_burnin};
+
+  static constexpr std::string_view model_internal_state_log_header =
+      "task_id\tepoch\tcell_id\tchrom\tburnin\tbarrier_occupancy\tnum_active_lefs\tnum_stalls_"
+      "rev\tnum_stalls_fwd\tnum_stalls_both\tnum_lef_bar_collisions\tnum_primary_lef_lef_"
+      "collisions\tnum_secondary_lef_lef_collisions\tavg_loop_size\n";
 
   absl::Span<char*> args;
   std::string argv_json{};

--- a/src/common/include/modle/common/utils.hpp
+++ b/src/common/include/modle/common/utils.hpp
@@ -42,9 +42,6 @@ struct XXH3_Deleter {
   inline void operator()(XXH3_state_t* state) noexcept;
 };
 
-[[maybe_unused]] [[nodiscard]] constexpr bool ndebug_defined() noexcept;
-[[maybe_unused]] [[nodiscard]] constexpr bool ndebug_not_defined() noexcept;
-
 #ifdef __has_cpp_attribute
 #if __has_cpp_attribute(clang::no_destroy)
 #define MODLE_NO_DESTROY [[clang::no_destroy]]
@@ -54,31 +51,6 @@ struct XXH3_Deleter {
 #else
 #define MODLE_NO_DESTROY
 #endif
-
-// Source: https://www.youtube.com/watch?v=INn3xa4pMfg
-template <class Key, class Value, usize Size>
-class ConstMap {
-  std::array<std::pair<Key, Value>, Size> _buff;
-
- public:
-  template <class... Args>
-  constexpr ConstMap(Args&&... args) noexcept;
-
-  using const_iterator = typename std::array<std::pair<Key, Value>, Size>::const_iterator;
-  using key_type = Key;
-  using mapped_type = Value;
-  using value_type = std::pair<const Key, Value>;
-  using first_type = const Key;
-  using second_type = Value;
-
-  [[nodiscard]] constexpr const Value& at(const Key& key) const;
-  [[nodiscard]] constexpr const Value& operator[](const Key& key) const;
-  [[nodiscard]] constexpr const_iterator find(const Key& key) const noexcept;
-  [[nodiscard]] constexpr bool contains(const Key& key) const noexcept;
-
-  [[nodiscard]] constexpr const_iterator begin() const noexcept;
-  [[nodiscard]] constexpr const_iterator end() const noexcept;
-};
 
 template <class T>
 class RepeatIterator {

--- a/src/common/utils_impl.hpp
+++ b/src/common/utils_impl.hpp
@@ -52,63 +52,11 @@ constexpr auto get_printable_type_name() noexcept {
   return name;
 }
 
-constexpr bool ndebug_defined() noexcept {
-#ifdef NDEBUG
-  return true;
-#else
-  return false;
-#endif
-}
-
-constexpr bool ndebug_not_defined() noexcept { return !ndebug_defined(); }
-
 void XXH3_Deleter::operator()(XXH3_state_t *state) noexcept { XXH3_freeState(state); }
 
 template <class T>
 constexpr T &&identity::operator()(T &&a) const noexcept {
   return std::forward<T>(a);
-}
-
-template <class Key, class Value, usize Size>
-template <class... Args>
-constexpr ConstMap<Key, Value, Size>::ConstMap(Args &&...args) noexcept
-    : _buff{{std::forward<Args>(args)...}} {}
-
-template <class Key, class Value, usize Size>
-constexpr const Value &ConstMap<Key, Value, Size>::at(const Key &key) const {
-  const auto itr = this->find(key);
-  if (itr != this->end()) {
-    return itr->second;
-  }
-  throw std::range_error(fmt::format(FMT_STRING("Unable to find key \"{}\""), key));
-}
-
-template <class Key, class Value, usize Size>
-constexpr const Value &ConstMap<Key, Value, Size>::operator[](const Key &key) const {
-  return *this->find(key);
-}
-
-template <class Key, class Value, usize Size>
-constexpr typename ConstMap<Key, Value, Size>::const_iterator ConstMap<Key, Value, Size>::find(
-    const Key &key) const noexcept {
-  return std::find_if(this->begin(), this->end(), [&key](const auto &v) { return v.first == key; });
-}
-
-template <class Key, class Value, usize Size>
-constexpr bool ConstMap<Key, Value, Size>::contains(const Key &key) const noexcept {
-  return this->find(key) != this->_buff.end();
-}
-
-template <class Key, class Value, usize Size>
-constexpr typename ConstMap<Key, Value, Size>::const_iterator ConstMap<Key, Value, Size>::begin()
-    const noexcept {
-  return this->_buff.begin();
-}
-
-template <class Key, class Value, usize Size>
-constexpr typename ConstMap<Key, Value, Size>::const_iterator ConstMap<Key, Value, Size>::end()
-    const noexcept {
-  return this->_buff.end();
 }
 
 template <class T>

--- a/src/libmodle/cpu/include/modle/simulation.hpp
+++ b/src/libmodle/cpu/include/modle/simulation.hpp
@@ -190,10 +190,7 @@ class Simulation : Config {
   std::mutex _exceptions_mutex{};
   thread_pool _tpool;
 
-  static constexpr std::string_view model_state_log_header =
-      "task_id\tepoch\tcell_id\tchrom\tburnin\tbarrier_occupancy\tnum_active_lefs\tnum_stalls_"
-      "rev\tnum_stalls_fwd\tnum_stalls_both\tnum_lef_bar_collisions\tnum_primary_lef_lef_"
-      "collisions\tnum_secondary_lef_lef_collisions\tavg_loop_size\n";
+  static constexpr auto& model_internal_state_log_header = Config::model_internal_state_log_header;
 
   [[nodiscard]] bool ok() const noexcept;
 

--- a/src/libmodle/cpu/simulation.cpp
+++ b/src/libmodle/cpu/simulation.cpp
@@ -56,11 +56,10 @@ namespace modle {
 
 Simulation::Simulation(const Config& c, bool import_chroms)
     : Config(c),
-      _genome(import_chroms
-                  ? Genome(path_to_chrom_sizes, path_to_extr_barriers, path_to_chrom_subranges,
-                           path_to_feature_bed_files, ctcf_occupied_self_prob,
-                           ctcf_not_occupied_self_prob, write_contacts_for_ko_chroms)
-                  : Genome{}) {
+      _genome(import_chroms ? Genome(path_to_chrom_sizes, path_to_extr_barriers,
+                                     path_to_chrom_subranges, path_to_feature_bed_files,
+                                     ctcf_occupied_self_prob, ctcf_not_occupied_self_prob)
+                            : Genome{}) {
   DISABLE_WARNING_PUSH
   DISABLE_WARNING_SHORTEN_64_TO_32
   _tpool.reset(c.nthreads + 1);
@@ -169,7 +168,7 @@ void Simulation::write_contacts_to_disk(std::deque<std::pair<Chromosome*, usize>
           spdlog::info(FMT_STRING("Writing contacts for \"{}\" to file {}..."),
                        chrom_to_be_written->name(), c->get_path());
         } else {
-          spdlog::info(FMT_STRING("Creating an empty entry for \"{}\" in file {}..."),
+          spdlog::info(FMT_STRING("Writing bin table for \"{}\" to file {}..."),
                        chrom_to_be_written->name(), c->get_path());
         }
 
@@ -186,9 +185,6 @@ void Simulation::write_contacts_to_disk(std::deque<std::pair<Chromosome*, usize>
               static_cast<double>(chrom_to_be_written->contacts().get_nnz()) / 1.0e6,
               static_cast<double>(chrom_to_be_written->contacts().npixels()) / 1.0e6,
               c->get_path());
-        } else {
-          spdlog::info(FMT_STRING("Created an entry for \"{}\" in file {}."),
-                       chrom_to_be_written->name(), c->get_path());
         }
       }
       // Deallocate the contact matrix to free up unused memory

--- a/src/libmodle/internal/genome.cpp
+++ b/src/libmodle/internal/genome.cpp
@@ -36,47 +36,37 @@
 namespace modle {
 
 Chromosome::Chromosome(usize id, const bed::BED& chrom,
-                       const IITree<bp_t, ExtrusionBarrier>& barriers, bool ok_)
-    : Chromosome(id, chrom.chrom, chrom.thick_start, chrom.thick_end, chrom.size(), barriers, ok_) {
-}
+                       const IITree<bp_t, ExtrusionBarrier>& barriers)
+    : Chromosome(id, chrom.chrom, chrom.thick_start, chrom.thick_end, chrom.size(), barriers) {}
 
-Chromosome::Chromosome(usize id, const bed::BED& chrom, bool ok_)
+Chromosome::Chromosome(usize id, const bed::BED& chrom)
     : _name(chrom.chrom),
       _start(chrom.chrom_start),
       _end(chrom.chrom_end),
       _size(chrom.size()),
-      _id(id),
-      _ok(ok_) {}
+      _id(id) {}
 
-Chromosome::Chromosome(usize id, const bed::BED& chrom, IITree<bp_t, ExtrusionBarrier>&& barriers,
-                       bool ok_)
-    : Chromosome(id, chrom.chrom, chrom.thick_start, chrom.thick_end, chrom.size(), barriers, ok_) {
-}
+Chromosome::Chromosome(usize id, const bed::BED& chrom, IITree<bp_t, ExtrusionBarrier>&& barriers)
+    : Chromosome(id, chrom.chrom, chrom.thick_start, chrom.thick_end, chrom.size(), barriers) {}
 
 DISABLE_WARNING_PUSH
 DISABLE_WARNING_SIGN_CONVERSION
 DISABLE_WARNING_CONVERSION
 Chromosome::Chromosome(usize id, std::string_view chrom_name, bp_t chrom_start, bp_t chrom_end,
-                       bp_t chrom_size, bool ok_)
-    : _name(chrom_name),
-      _start(chrom_start),
-      _end(chrom_end),
-      _size(chrom_size),
-      _id(id),
-      _ok(ok_) {
+                       bp_t chrom_size)
+    : _name(chrom_name), _start(chrom_start), _end(chrom_end), _size(chrom_size), _id(id) {
   assert(chrom_start <= chrom_end);
   assert(chrom_end - chrom_start <= chrom_size);
 }
 
 Chromosome::Chromosome(usize id, std::string_view chrom_name, bp_t chrom_start, bp_t chrom_end,
-                       bp_t chrom_size, const IITree<bp_t, ExtrusionBarrier>& barriers, bool ok_)
+                       bp_t chrom_size, const IITree<bp_t, ExtrusionBarrier>& barriers)
     : _name(chrom_name),
       _start(chrom_start),
       _end(chrom_end),
       _size(chrom_size),
       _id(id),
-      _barriers(barriers),
-      _ok(ok_) {
+      _barriers(barriers) {
   assert(chrom_start <= chrom_end);
   assert(chrom_end - chrom_start <= chrom_size);
 
@@ -84,14 +74,13 @@ Chromosome::Chromosome(usize id, std::string_view chrom_name, bp_t chrom_start, 
 }
 
 Chromosome::Chromosome(usize id, std::string_view chrom_name, bp_t chrom_start, bp_t chrom_end,
-                       bp_t chrom_size, IITree<bp_t, ExtrusionBarrier>&& barriers, bool ok_)
+                       bp_t chrom_size, IITree<bp_t, ExtrusionBarrier>&& barriers)
     : _name(chrom_name),
       _start(chrom_start),
       _end(chrom_end),
       _size(chrom_size),
       _id(id),
-      _barriers(std::move(barriers)),
-      _ok(ok_) {
+      _barriers(std::move(barriers)) {
   assert(chrom_start <= chrom_end);
   assert(chrom_end - chrom_start <= chrom_size);
 
@@ -107,8 +96,7 @@ Chromosome::Chromosome(const Chromosome& other)
       _id(other._id),
       _barriers(other._barriers),
       _contacts(other._contacts),
-      _features(other._features),
-      _ok(other._ok) {
+      _features(other._features) {
   _barriers.make_BST();
 }
 
@@ -120,8 +108,7 @@ Chromosome::Chromosome(Chromosome&& other) noexcept
       _id(other._id),
       _barriers(std::move(other._barriers)),
       _contacts(std::move(other._contacts)),
-      _features(std::move(other._features)),
-      _ok(other._ok) {
+      _features(std::move(other._features)) {
   _barriers.make_BST();
 }
 
@@ -138,7 +125,6 @@ Chromosome& Chromosome::operator=(const Chromosome& other) {
   _barriers = other._barriers;
   _contacts = other._contacts;
   _features = other._features;
-  _ok = other._ok;
 
   _barriers.make_BST();
 
@@ -158,7 +144,6 @@ Chromosome& Chromosome::operator=(Chromosome&& other) noexcept {
   _barriers = std::move(other._barriers);
   _contacts = std::move(other._contacts);
   _features = std::move(other._features);
-  _ok = other._ok;
 
   _barriers.make_BST();
 
@@ -219,8 +204,6 @@ void Chromosome::add_extrusion_barrier(const bed::BED& record, const double ctcf
 usize Chromosome::id() const { return this->_id; }
 std::string_view Chromosome::name() const { return this->_name; }
 const char* Chromosome::name_cstr() const { return this->_name.c_str(); }
-
-bool Chromosome::ok() const { return this->_ok; }
 
 usize Chromosome::num_lefs(double nlefs_per_mbp) const {
   return static_cast<usize>((static_cast<double>(this->simulated_size()) / 1.0e6) * nlefs_per_mbp);
@@ -311,16 +294,14 @@ Genome::Genome(const boost::filesystem::path& path_to_chrom_sizes,
                const boost::filesystem::path& path_to_extr_barriers,
                const boost::filesystem::path& path_to_chrom_subranges,
                const absl::Span<const boost::filesystem::path> paths_to_extra_features,
-               const double ctcf_prob_occ_to_occ, const double ctcf_prob_nocc_to_nocc,
-               bool keep_all_chroms)
-    : _chromosomes(instantiate_genome(
-          path_to_chrom_sizes, path_to_extr_barriers, path_to_chrom_subranges,
-          paths_to_extra_features, ctcf_prob_occ_to_occ, ctcf_prob_nocc_to_nocc, keep_all_chroms)) {
-}
+               const double ctcf_prob_occ_to_occ, const double ctcf_prob_nocc_to_nocc)
+    : _chromosomes(instantiate_genome(path_to_chrom_sizes, path_to_extr_barriers,
+                                      path_to_chrom_subranges, paths_to_extra_features,
+                                      ctcf_prob_occ_to_occ, ctcf_prob_nocc_to_nocc)) {}
 
 absl::btree_set<Chromosome> Genome::import_chromosomes(
     const boost::filesystem::path& path_to_chrom_sizes,
-    const boost::filesystem::path& path_to_chrom_subranges, bool keep_all_chroms) {
+    const boost::filesystem::path& path_to_chrom_subranges) {
   assert(!path_to_chrom_sizes.empty());
 
   const auto t0 = absl::Now();
@@ -389,10 +370,8 @@ absl::btree_set<Chromosome> Genome::import_chromosomes(
       record.thick_end = record.chrom_end;
     }
 
-    if (keep_all_chroms || match != chrom_ranges.end()) {
-      chromosomes.emplace(id++, record.chrom, record.thick_start, record.thick_end, record.size(),
-                          match != chrom_ranges.end());
-    }
+    chromosomes.emplace(id++, record.chrom, record.thick_start, record.thick_end, record.size(),
+                        match != chrom_ranges.end());
   }
 
   print_status_update_on_return(chromosomes.size());
@@ -465,8 +444,8 @@ absl::btree_set<Chromosome> Genome::instantiate_genome(
     const boost::filesystem::path& path_to_extr_barriers,
     const boost::filesystem::path& path_to_chrom_subranges,
     const absl::Span<const boost::filesystem::path> paths_to_extra_features,
-    const double ctcf_prob_occ_to_occ, const double ctcf_prob_nocc_to_nocc, bool keep_all_chroms) {
-  auto chroms = import_chromosomes(path_to_chrom_sizes, path_to_chrom_subranges, keep_all_chroms);
+    const double ctcf_prob_occ_to_occ, const double ctcf_prob_nocc_to_nocc) {
+  auto chroms = import_chromosomes(path_to_chrom_sizes, path_to_chrom_subranges);
 
   if (chroms.empty()) {
     if (path_to_chrom_subranges.empty()) {

--- a/src/libmodle/internal/include/modle/genome.hpp
+++ b/src/libmodle/internal/include/modle/genome.hpp
@@ -37,18 +37,16 @@ class Chromosome {
  public:
   Chromosome() = default;
   Chromosome(usize id, std::string_view chrom_name, bp_t chrom_start, bp_t chrom_end,
-             bp_t chrom_size, bool ok_ = true);
+             bp_t chrom_size);
 
-  Chromosome(usize id, const bed::BED& chrom, bool ok_ = true);
-  Chromosome(usize id, const bed::BED& chrom, const IITree<bp_t, ExtrusionBarrier>& barriers,
-             bool ok_ = true);
-  Chromosome(usize id, const bed::BED& chrom, IITree<bp_t, ExtrusionBarrier>&& barriers,
-             bool ok_ = true);
+  Chromosome(usize id, const bed::BED& chrom);
+  Chromosome(usize id, const bed::BED& chrom, const IITree<bp_t, ExtrusionBarrier>& barriers);
+  Chromosome(usize id, const bed::BED& chrom, IITree<bp_t, ExtrusionBarrier>&& barriers);
 
   Chromosome(usize id, std::string_view chrom_name, bp_t chrom_start, bp_t chrom_end,
-             bp_t chrom_size, const IITree<bp_t, ExtrusionBarrier>& barriers, bool ok_ = true);
+             bp_t chrom_size, const IITree<bp_t, ExtrusionBarrier>& barriers);
   Chromosome(usize id, std::string_view chrom_name, bp_t chrom_start, bp_t chrom_end,
-             bp_t chrom_size, IITree<bp_t, ExtrusionBarrier>&& barriers, bool ok_ = true);
+             bp_t chrom_size, IITree<bp_t, ExtrusionBarrier>&& barriers);
 
   ~Chromosome() = default;
 
@@ -79,7 +77,6 @@ class Chromosome {
   [[nodiscard]] constexpr bp_t simulated_size() const;
   [[nodiscard]] usize npixels() const;
   [[nodiscard]] constexpr usize npixels(bp_t diagonal_width, bp_t bin_size) const;
-  [[nodiscard]] bool ok() const;
   [[nodiscard]] usize num_lefs(double nlefs_per_mbp) const;
   [[nodiscard]] usize num_barriers() const;
   [[nodiscard]] const IITree<bp_t, ExtrusionBarrier>& barriers() const;
@@ -109,7 +106,6 @@ class Chromosome {
   std::shared_ptr<contact_matrix_t> _contacts{};
 
   std::vector<bed_tree_value_t> _features{};
-  bool _ok{true};
 };
 
 class Genome {
@@ -119,7 +115,7 @@ class Genome {
          const boost::filesystem::path& path_to_extr_barriers,
          const boost::filesystem::path& path_to_chrom_subranges,
          absl::Span<const boost::filesystem::path> paths_to_extra_features,
-         double ctcf_prob_occ_to_occ, double ctcf_prob_nocc_to_nocc, bool keep_all_chroms);
+         double ctcf_prob_occ_to_occ, double ctcf_prob_nocc_to_nocc);
 
   using iterator = absl::btree_set<Chromosome>::iterator;
   using const_iterator = absl::btree_set<Chromosome>::const_iterator;
@@ -163,7 +159,7 @@ class Genome {
       const boost::filesystem::path& path_to_extr_barriers,
       const boost::filesystem::path& path_to_chrom_subranges,
       absl::Span<const boost::filesystem::path> paths_to_extra_features,
-      double ctcf_prob_occ_to_occ, double ctcf_prob_nocc_to_nocc, bool keep_all_chroms);
+      double ctcf_prob_occ_to_occ, double ctcf_prob_nocc_to_nocc);
 
  private:
   absl::btree_set<Chromosome> _chromosomes{};
@@ -175,7 +171,7 @@ class Genome {
   //! simulate loop extrusion on a sub-region of a chromosome from the chrom.sizes file.
   [[nodiscard]] static absl::btree_set<Chromosome> import_chromosomes(
       const boost::filesystem::path& path_to_chrom_sizes,
-      const boost::filesystem::path& path_to_chrom_subranges, bool keep_all_chroms);
+      const boost::filesystem::path& path_to_chrom_subranges);
 
   /// Parse a BED file containing the genomic coordinates of extrusion barriers and add them to the
   /// Genome

--- a/src/libmodle_io/bed.cpp
+++ b/src/libmodle_io/bed.cpp
@@ -39,11 +39,11 @@ namespace modle::bed {
 std::string RGB::to_string() const { return fmt::to_string(*this); }
 
 void BED::parse_strand_or_throw(const std::vector<std::string_view>& toks, u8 idx, char& field) {
-  const auto* const match = bed_strand_encoding.find(toks[idx]);
+  const auto match = bed_strand_encoding.find(toks[idx]);
   if (match == bed_strand_encoding.end()) {
     throw std::runtime_error(fmt::format(FMT_STRING("Unrecognized strand \"{}\""), toks[idx]));
   }
-  field = match->second;
+  field = *match.second;
 }
 
 void BED::parse_rgb_or_throw(const std::vector<std::string_view>& toks, u8 idx, RGB& field) {

--- a/src/libmodle_io/bigwig.cpp
+++ b/src/libmodle_io/bigwig.cpp
@@ -18,7 +18,6 @@
 
 #include "libBigWig/bigWig.h"  // for bwCleanup, bwClose, bwAddIntervalSpanSteps, bwCreateChromList
 #include "modle/common/common.hpp"  // for u32, u64, i32, i64
-#include "modle/common/utils.hpp"   // for ndebug_not_defined
 
 namespace modle::io::bigwig {
 

--- a/src/libmodle_io/cooler_write_impl.hpp
+++ b/src/libmodle_io/cooler_write_impl.hpp
@@ -360,10 +360,12 @@ void Cooler<N>::write_or_append_cmatrix_to_file(const ContactMatrix<M> *cmatrix,
     idx_bin1_offset_h5_foffset =
         hdf5::write_numbers(b.idx_bin1_offset_buff, d[IDX_BIN1], idx_bin1_offset_h5_foffset);
 
-    DISABLE_WARNING_PUSH
-    DISABLE_WARNING_USELESS_CAST
-    this->_sum += static_cast<sum_t>(cmatrix->get_tot_contacts());
-    DISABLE_WARNING_POP
+    if (cmatrix) {  // Guard against nullptr deref
+      DISABLE_WARNING_PUSH
+      DISABLE_WARNING_USELESS_CAST
+      this->_sum += static_cast<sum_t>(cmatrix->get_tot_contacts());
+      DISABLE_WARNING_POP
+    }
 
     auto &f = *this->_fp;
     hdf5::write_or_create_attribute(f, "nchroms", this->_nchroms);

--- a/src/libmodle_io/include/bed/modle/bed/bed.hpp
+++ b/src/libmodle_io/include/bed/modle/bed/bed.hpp
@@ -19,8 +19,8 @@
 #include <utility>                    // for make_pair, pair
 #include <vector>                     // for vector
 
-#include "modle/common/common.hpp"  // for bp_t, u64, u8
-#include "modle/common/utils.hpp"   // for ConstMap, ConstMap::ConstMap<Key, Value, Size>
+#include "modle/common/common.hpp"     // for bp_t, u64, u8
+#include "modle/common/const_map.hpp"  // for ConstMap, ConstMap::ConstMap<Key, Value, Size>
 #include "modle/compressed_io/compressed_io.hpp"  // for Reader
 #include "modle/interval_tree.hpp"                // for IITree, IITree::IITree<I, T>
 
@@ -239,32 +239,34 @@ class Parser {
 
 using namespace std::literals::string_view_literals;
 
+// clang-format off
 static constexpr utils::ConstMap<std::string_view, char, 26> bed_strand_encoding{
-    std::make_pair("+"sv, '+'),       std::make_pair("plus"sv, '+'),
-    std::make_pair("fwd"sv, '+'),     std::make_pair("Fwd"sv, '+'),
-    std::make_pair("forward"sv, '+'), std::make_pair("Forward"sv, '+'),
-    std::make_pair("FWD"sv, '+'),     std::make_pair("FORWARD"sv, '+'),
-    std::make_pair("-"sv, '-'),       std::make_pair("minus"sv, '-'),
-    std::make_pair("rev"sv, '-'),     std::make_pair("Rev"sv, '-'),
-    std::make_pair("reverse"sv, '-'), std::make_pair("Reverse"sv, '-'),
-    std::make_pair("REV"sv, '-'),     std::make_pair("REVERSE"sv, '-'),
-    std::make_pair("."sv, '.'),       std::make_pair(""sv, '.'),
-    std::make_pair("none"sv, '.'),    std::make_pair("None"sv, '.'),
-    std::make_pair("NONE"sv, '.'),    std::make_pair("unknown"sv, '.'),
-    std::make_pair("Unknown"sv, '.'), std::make_pair("unk"sv, '.'),
-    std::make_pair("Unk"sv, '.'),     std::make_pair("UNK"sv, '.')};
+    {"+"sv, '+'},       {"plus"sv, '+'},
+    {"fwd"sv, '+'},     {"Fwd"sv, '+'},
+    {"forward"sv, '+'}, {"Forward"sv, '+'},
+    {"FWD"sv, '+'},     {"FORWARD"sv, '+'},
+    {"-"sv, '-'},       {"minus"sv, '-'},
+    {"rev"sv, '-'},     {"Rev"sv, '-'},
+    {"reverse"sv, '-'}, {"Reverse"sv, '-'},
+    {"REV"sv, '-'},     {"REVERSE"sv, '-'},
+    {"."sv, '.'},       {""sv, '.'},
+    {"none"sv, '.'},    {"None"sv, '.'},
+    {"NONE"sv, '.'},    {"unknown"sv, '.'},
+    {"Unknown"sv, '.'}, {"unk"sv, '.'},
+    {"Unk"sv, '.'},     {"UNK"sv, '.'}};
+// clang-format on
 
 static constexpr std::array<std::string_view, 6> bed_dialects{"BED3"sv, "BED4"sv, "BED5"sv,
                                                               "BED6"sv, "BED9"sv, "BED12"sv};
 static constexpr utils::ConstMap<std::string_view, BED::Dialect, 6> str_to_bed_dialect_mappings{
-    std::make_pair("BED3"sv, BED::Dialect::BED3), std::make_pair("BED4"sv, BED::Dialect::BED4),
-    std::make_pair("BED5"sv, BED::Dialect::BED5), std::make_pair("BED6"sv, BED::Dialect::BED6),
-    std::make_pair("BED9"sv, BED::Dialect::BED9), std::make_pair("BED12"sv, BED::Dialect::BED12)};
+    {"BED3"sv, BED::Dialect::BED3}, {"BED4"sv, BED::Dialect::BED4},
+    {"BED5"sv, BED::Dialect::BED5}, {"BED6"sv, BED::Dialect::BED6},
+    {"BED9"sv, BED::Dialect::BED9}, {"BED12"sv, BED::Dialect::BED12}};
 
 static constexpr utils::ConstMap<BED::Dialect, std::string_view, 6> bed_dialect_to_str_mappings{
-    std::make_pair(BED::Dialect::BED3, "BED3"sv), std::make_pair(BED::Dialect::BED4, "BED4"sv),
-    std::make_pair(BED::Dialect::BED5, "BED5"sv), std::make_pair(BED::Dialect::BED6, "BED6"sv),
-    std::make_pair(BED::Dialect::BED9, "BED9"sv), std::make_pair(BED::Dialect::BED12, "BED12"sv)};
+    {BED::Dialect::BED3, "BED3"sv}, {BED::Dialect::BED4, "BED4"sv},
+    {BED::Dialect::BED5, "BED5"sv}, {BED::Dialect::BED6, "BED6"sv},
+    {BED::Dialect::BED9, "BED9"sv}, {BED::Dialect::BED12, "BED12"sv}};
 
 }  // namespace modle::bed
 

--- a/src/modle/CMakeLists.txt
+++ b/src/modle/CMakeLists.txt
@@ -17,8 +17,6 @@ target_link_libraries(
   modle
   PRIVATE project_warnings
           project_options
-          CLI11::CLI11
-          fmt::fmt
           Modle::common
           Modle::config
           Modle::io_cooler
@@ -28,6 +26,7 @@ target_link_system_libraries(
   modle
   PRIVATE
   absl::failure_signal_handler
+  absl::flat_hash_map
   absl::span
   absl::strings
   absl::symbolize

--- a/src/modle/cli.cpp
+++ b/src/modle/cli.cpp
@@ -355,12 +355,6 @@ static void add_common_options(CLI::App& subcommand, modle::Config& c) {
       ->check(CLI::Range(0.0, 1.0))
       ->capture_default_str();
 
-  extr_barr.add_flag(
-      "--exclude-chrom-wo-barriers,!--keep-chrom-without-barriers",
-      c.exclude_chrom_wo_extr_barriers,
-      "Do not simulate loop extrusion on chromosomes without any extrusion barrier.")
-      ->capture_default_str();
-
   rand.add_option(
       "--mu,--genextr-location",
       c.genextreme_mu,
@@ -522,12 +516,6 @@ void Cli::make_perturbate_subcommand() {
       c.path_to_deletion_bed,
       "Path to a BED file containing the list deletions to perform when perturbating extrusion barriers.")
       ->check(CLI::ExistingFile);
-
-  gen.add_flag(
-      "--write-tasks,!--no-write-taks",
-      c.write_tasks_to_disk,
-      "Write tasks to disk.")
-      ->capture_default_str();
   // clang-format on
 
   gen.get_option("--deletion-size")->excludes("--deletion-list");

--- a/src/modle/cli.cpp
+++ b/src/modle/cli.cpp
@@ -189,7 +189,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "Average LEF processivity in bp.\n"
       "The average LEF processivity corresponds to the average size of loops extruded by\n"
       "unobstructed LEFs.")
-      ->check(CLI::PositiveNumber)
+      ->check(CLI::PositiveNumber | utils::cli::AsGenomicDistance)
       ->capture_default_str();
 
   lefbar.add_option(
@@ -239,7 +239,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "Moving distances can be shortened by collision events taking place during the current epoch.\n"
       "By deafult extrusion speed is set to half the bin size specified through the --resolution\n"
       "option.")
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit |  utils::cli::AsGenomicDistance)
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
@@ -247,7 +247,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "--rev-extrusion-speed",
       c.rev_extrusion_speed,
       "Same as --fwd-extrusion-speed but for extrusion units moving in 3'-5' direction.")
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit |  utils::cli::AsGenomicDistance)
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
@@ -310,7 +310,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       c.contact_sampling_strategy,
       fmt::format(FMT_STRING("Strategy to use when sampling contacts.\n"
                              "Should be one of:\n"
-                             "- {}\n"
+                             " - {}\n"
                              "When one of the *-with-noise strategies is specified, contacts are randomized by\n"
                              "applying a random offset to the location of LEF extrusion units.\n"
                              "Offsets are drawn from a genextreme distrubution.\n"
@@ -337,7 +337,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "NOTE: MoDLE simulation always take place at 1 bp resolution.\n"
       "      This parameter only affects the resolution of the output contact matrix.")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit | utils::cli::AsGenomicDistance)
       ->capture_default_str();
 
   cgen.add_option(
@@ -350,7 +350,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "Setting --diagonal-width to very large values (i.e. tens of Mbp) will significantly\n"
       "increase MoDLE's memory requirements.")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit | utils::cli::AsGenomicDistance)
       ->capture_default_str();
 
   cgen_adv.add_option(
@@ -408,7 +408,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "Each simulation instance will run exactly --target-number-of-epochs epochs after burn-in\n"
       "phase. Has no effect when --stopping-criterion=\"contact-density\".")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit)
       ->capture_default_str();
 
   stopping.add_option(
@@ -433,7 +433,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "generated across all simulation instances. To achieve good performance and CPU utilization\n"
       "we recommend setting --ncells equal to the number of available CPU cores.")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit)
       ->capture_default_str();
 
   misc.add_option(
@@ -452,7 +452,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       c.seed,
       "Base seed to use for random number generation.")
       ->check(CLI::NonNegativeNumber)
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit)
       ->capture_default_str();
 
   burnin_adv.add_flag(
@@ -606,7 +606,7 @@ void Cli::make_perturbate_subcommand() {
       "Size of the block of pixels to use when generating contacts for a pair of features. Must be an odd number.")
       ->check(CLI::Range(1UL, std::numeric_limits<decltype(c.block_size)>::max()) |
               CLI::Validator(is_odd_number, "ODD-NUMBER", ""))
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit)
       ->capture_default_str();
 
   misc.add_option(
@@ -615,7 +615,7 @@ void Cli::make_perturbate_subcommand() {
       "Size of deletion in bp. Used to enable/disable extrusion barriers and compute the total number of contacts between pairs of feats1.\n"
       "Specify 0 to compute all possible combinations. Ignored when --mode=\"cluster\".")
       ->check(CLI::NonNegativeNumber)
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit)
       ->capture_default_str();
 
   misc.add_option(

--- a/src/modle/cli.cpp
+++ b/src/modle/cli.cpp
@@ -239,7 +239,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "Moving distances can be shortened by collision events taking place during the current epoch.\n"
       "By deafult extrusion speed is set to half the bin size specified through the --resolution\n"
       "option.")
-      ->transform(utils::str_float_to_str_int)
+      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
@@ -247,7 +247,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "--rev-extrusion-speed",
       c.rev_extrusion_speed,
       "Same as --fwd-extrusion-speed but for extrusion units moving in 3'-5' direction.")
-      ->transform(utils::str_float_to_str_int)
+      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
@@ -337,7 +337,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "NOTE: MoDLE simulation always take place at 1 bp resolution.\n"
       "      This parameter only affects the resolution of the output contact matrix.")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::str_float_to_str_int)
+      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
       ->capture_default_str();
 
   cgen.add_option(
@@ -350,7 +350,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "Setting --diagonal-width to very large values (i.e. tens of Mbp) will significantly\n"
       "increase MoDLE's memory requirements.")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::str_float_to_str_int)
+      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
       ->capture_default_str();
 
   cgen_adv.add_option(
@@ -408,7 +408,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "Each simulation instance will run exactly --target-number-of-epochs epochs after burn-in\n"
       "phase. Has no effect when --stopping-criterion=\"contact-density\".")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::str_float_to_str_int)
+      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
       ->capture_default_str();
 
   stopping.add_option(
@@ -433,7 +433,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       "generated across all simulation instances. To achieve good performance and CPU utilization\n"
       "we recommend setting --ncells equal to the number of available CPU cores.")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::str_float_to_str_int)
+      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
       ->capture_default_str();
 
   misc.add_option(
@@ -452,7 +452,7 @@ static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Co
       c.seed,
       "Base seed to use for random number generation.")
       ->check(CLI::NonNegativeNumber)
-      ->transform(utils::str_float_to_str_int)
+      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
       ->capture_default_str();
 
   burnin_adv.add_flag(
@@ -606,7 +606,7 @@ void Cli::make_perturbate_subcommand() {
       "Size of the block of pixels to use when generating contacts for a pair of features. Must be an odd number.")
       ->check(CLI::Range(1UL, std::numeric_limits<decltype(c.block_size)>::max()) |
               CLI::Validator(is_odd_number, "ODD-NUMBER", ""))
-      ->transform(utils::str_float_to_str_int)
+      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
       ->capture_default_str();
 
   misc.add_option(
@@ -615,7 +615,7 @@ void Cli::make_perturbate_subcommand() {
       "Size of deletion in bp. Used to enable/disable extrusion barriers and compute the total number of contacts between pairs of feats1.\n"
       "Specify 0 to compute all possible combinations. Ignored when --mode=\"cluster\".")
       ->check(CLI::NonNegativeNumber)
-      ->transform(utils::str_float_to_str_int)
+      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
       ->capture_default_str();
 
   misc.add_option(
@@ -705,7 +705,7 @@ void Cli::make_cli() {
   this->_cli.set_version_flag("-V,--version", std::string{modle::config::version::str_long()});
   this->_cli.require_subcommand(1);
   this->_cli.set_config("--config", "", "Path to MoDLE's config file (optional).", false);
-  this->_cli.formatter(std::make_shared<utils::Formatter>());
+  this->_cli.formatter(std::make_shared<utils::cli::Formatter>());
   this->_cli.get_formatter()->column_width(30);
 
   auto option_ptrs = this->_cli.get_options();

--- a/src/modle/cli.cpp
+++ b/src/modle/cli.cpp
@@ -38,7 +38,7 @@
 
 namespace modle {
 
-static std::string is_odd_number(std::string_view s) {
+static std::string is_odd_number(std::string_view s) noexcept {
   try {
     const auto n = utils::parse_numeric_or_throw<i64>(s);
     if (n % 2 == 0) {
@@ -62,15 +62,38 @@ std::ostream& operator<<(std::ostream& os, const Config::ContactSamplingStrategy
   return os;
 }
 
-static void add_common_options(CLI::App& subcommand, modle::Config& c) {
+static void add_common_options(CLI::App& subcommand, modle::Config& config) {
   auto& s = subcommand;
+  auto& c = config;
 
-  auto& io = *s.add_option_group("Input/Output", "");
-  auto& gen = *s.add_option_group("Generic", "");
-  auto& prob = *s.add_option_group("Probabilities", "");
-  auto& rand = *s.add_option_group("Random", "");
-  auto& extr_barr = *s.add_option_group("Extrusion Barriers", "");
-  auto& dbg = *s.add_option_group("Debug/Profiling", "");
+  auto& io = *s.add_option_group("IO", "Options controlling MoDLE input, output and logs.");
+
+  auto& lefbar =
+      *s.add_option_group("Extrusion Barriers and Factors",
+                          "Options controlling how extrusion barrier and LEFs are simulated.");
+
+  auto& cgen = *s.add_option_group("Contact generation",
+                                   "Options affecting contact sampling and registration.");
+
+  auto& stopping = *s.add_option_group("Stopping criterion",
+                                       "Options defining the simulation stopping criterion.");
+
+  auto& misc = *s.add_option_group("Miscellaneous");
+
+  auto& io_adv = *s.add_option_group("Advanced/IO",
+                                     "Advanced options controlling MoDLE input, output and logs.");
+  auto& lef_adv = *s.add_option_group("Advanced/Extrusion Factors",
+                                      "Advanced options controlling how LEFs are simulated.");
+
+  auto& barr_adv = *s.add_option_group("Advanced/Extrusion Barriers",
+                                       "Advanced options controlling how extrusion are simulated.");
+
+  auto& cgen_adv =
+      *s.add_option_group("Advanced/Contact generation",
+                          "Advanced options affecting contact sampling and registration.");
+
+  auto& burnin_adv = *s.add_option_group("Advanced/Burn-in",
+                                         "Options defining the simulation stopping criterion.");
 
   // clang-format off
   io.add_option(
@@ -79,66 +102,271 @@ static void add_common_options(CLI::App& subcommand, modle::Config& c) {
       "Path to file with chromosome sizes in chrom.sizes format.")
       ->check(CLI::ExistingFile)->required();
 
-  io.add_option(
+  io_adv.add_option(
       "--chrom-subranges",
       c.path_to_chrom_subranges,
       "Path to BED file with subranges of the chromosomes to simulate.")
       ->check(CLI::ExistingFile);
 
+  io.add_option(
+      "-b,--extrusion-barrier-file",
+      c.path_to_extr_barriers,
+      "Path to a file in BED6+ format with the genomic coordinates of extrusion barriers to be simulated.\n"
+      "The score field in a BED record should be a number between 0 and 1 and is interpreted as the extrusion barrier occupancy for the extrusion barrier described by the record.\n"
+      "Barriers mapping on chromosomes not listed in the chrom.sizes file passed through the --chrom-sizes option are ignored.")
+      ->check(CLI::ExistingFile)
+      ->required();
+
   io.add_flag(
       "-f,--force",
       c.force,
-      "Force overwrite of output files if they exists.")
+      "Overwrite existing files (if any).")
       ->capture_default_str();
+
+  io.add_option(
+      "-o,--output-prefix",
+      c.path_to_output_prefix,
+      "Output prefix.\n"
+      "Can be an absolute or relative path including the file name but without the extension.\n"
+      "Example: running modle sim -o /tmp/my_simulation ... yields the following files:\n"
+      "         - /tmp/my_simulation.cool\n"
+      "         - /tmp/my_simulation.log\n"
+      "         - /tmp/my_simulation_config.toml")
+      ->required();
 
   io.add_flag(
       "-q,--quiet",
       c.quiet,
-      "Only log fatal errors.")
+      "Suppress console output to stderr.\n"
+      "Only fatal errors will be logged to the console.\n"
+      "Does not affect entries written to the log file.")
       ->capture_default_str();
 
-  gen.add_option(
-      "-b,--bin-size",
+  io_adv.add_flag(
+      "--log-model-internal-state",
+      c.log_model_internal_state,
+      fmt::format(FMT_STRING(
+                      "Collect detailed statistics regarding the internal state of MoDLE simulation instance(s).\n"
+                      "Statistics will be written to a compressed file under the prefix specified through the --output-prefix option.\n"
+                      "Example: with --output-prefix=/tmp/myprefix, statistics will be written to file /tmp/myprefix_internal_state.log.gz.\n"
+                      "Depending on the input file(s) and parameters, specifying this option may hinder simulation throughput.\n"
+                      "Currently the following metrics are collected:\n"
+                      " - {}"),
+                  fmt::join(absl::StrSplit(Config::model_internal_state_log_header, '\t'), "\n - ")))
+      ->capture_default_str();
+
+  io_adv.add_flag(
+      "--simulate-chromosomes-wo-barriers,!--skip-chromosomes-wo-barriers",
+      c.simulate_chromosomes_wo_barriers,
+      "Enable/disable simulation of loop extrusion for chromosomes with 0 extrusion barriers.\n"
+      "When --skip-chromosomes-wo-barriers is passed, entries for chromosomes without barriers will "
+      "still be written to the output .cool file, but no contacts will be generated for those chromosomes.")
+      ->capture_default_str();
+
+  io_adv.add_flag(
+      "--skip-output",
+      c.skip_output,
+      "Do not write output files. Mostly useful for profiling.")
+      ->capture_default_str();
+
+  lefbar.add_option(
+      "--lef-density,--lefs-per-mbp",
+      c.number_of_lefs_per_mbp,
+      "Loop extrusion factor (LEF) density expressed as the number of LEF per Mbp of DNA simulated.")
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  lefbar.add_option(
+      "--avg-lef-processivity",
+      c.avg_lef_processivity,
+      "Average LEF processivity in bp.\n"
+      "The average LEF processivity corresponds to the average size of loops extruded by unobstructed LEFs.")
+      ->check(CLI::PositiveNumber)
+      ->capture_default_str();
+
+  lefbar.add_option(
+      "--probability-of-lef-bypass",
+      c.probability_of_extrusion_unit_bypass,
+      "Probability that two colliding LEFs will avoid collision by bypassing each other.")
+      ->check(CLI::Range(0.0, 1.0))
+      ->capture_default_str();
+
+  lefbar.add_option(
+      "--extrusion-barrier-occupancy",
+      c.extrusion_barrier_occupancy,
+      "Probability that an extrusion barrier is occupied (i.e. blocking) at any given time.\n"
+      "This parameter provides an easier mean to set --extrusion-barrier-bound-stp.\n"
+      "Passing this parameter will override barrier occupancies read from the BED file specified through --extrusion-barrier-file.")
+      ->check(CLI::Range(0.0, 1.0));
+
+  lef_adv.add_option(
+      "--hard-stall-lef-stability-multiplier",
+      c.hard_stall_lef_stability_multiplier,
+      "Coefficient to control the DNA-binding stability of LEFs that are stalled on both sides by a pair of "
+      "extrusion barriers in convergent orientation.\n"
+      "Setting this to 1 makes the DNA-binding stability of hard-stalled LEFs identical to that of unobstructed LEFs.\n"
+      "Has no effects when --lef-bar-major-collision-prob=0.")
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  lef_adv.add_option(
+      "--soft-stall-lef-stability-multiplier",
+      c.soft_stall_lef_stability_multiplier,
+      "Coefficient to control the DNA-binding stability of LEFs stalled by one or more extrusion barriers "
+      "in a non-blocking orientation.\n"
+      "Setting this to 1 makes the DNA-binding stability of soft-stalled LEFs identical to that of unobstructed LEFs.\n"
+      "Has no effects when --lef-bar-minor-collision-prob=0.")
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  lef_adv.add_option(
+      "--fwd-extrusion-speed",
+      c.fwd_extrusion_speed,
+      "Average extrusion speed expressed in bp/epoch for forward-moving extrusion units.\n"
+      "Extrusion units are assigned a candidate moving distance at the beginning of every epoch.\n"
+      "Moves are sampled from a normal distribution centered around --fwd-extrusion-speed and with --fwd-extrusion-speed-std as its standard deviation.\n"
+      "Candidate moves represent the maximum distance a given extrusion unit is set to travel during the current epoch.\n"
+      "Moving distances can be shortened by collision events taking place during the current epoch.\n"
+      "By deafult extrusion speed is set to half the bin size specified through the --resolution option.")
+      ->transform(utils::str_float_to_str_int)
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  lef_adv.add_option(
+      "--rev-extrusion-speed",
+      c.rev_extrusion_speed,
+      "Same as --fwd-extrusion-speed but for extrusion units moving in 3'-5' direction.")
+      ->transform(utils::str_float_to_str_int)
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  lef_adv.add_option(
+      "--fwd-extrusion-speed-std",
+      c.fwd_extrusion_speed_std,
+      "Standard deviation of the normal distribution used to sample candidate moves for extrusion units moving in 5'-3' direction.\n"
+      "See help message for --fwd-extrusion-speed for more details regarding candidate moves.\n"
+      "Specifying --fwd-extrusion-speed-std=0 will make candidate moves deterministic.\n"
+      "Standard deviations between 0 and 1 are interpreted a percentage of the average extrusion speed.\n"
+      "Example: when running modle sim --fwd-extrusion-speed=10000 ...\n"
+      "         --fwd-extrusion-speed-std=0.1 and --fwd-extrusion-speed-std=1000 are equivalent.")
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  lef_adv.add_option(
+      "--rev-extrusion-speed-std",
+      c.rev_extrusion_speed_std,
+      "Same as --fwd-extrusion-speed-std but for extrusion units moving in 3'-5' direction.")
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  barr_adv.add_option(
+      "--lef-bar-major-collision-prob",
+      c.lef_bar_major_collision_pblock,
+      "Probability of collision between LEFs and extrusion barriers where barriers are pointing towards the extrusion direction.")
+      ->check(CLI::Range(0.0, 1.0))
+      ->capture_default_str();
+
+  barr_adv.add_option(
+      "--lef-bar-minor-collision-prob",
+      c.lef_bar_minor_collision_pblock,
+      "Probability of collision between LEFs and extrusion barriers where barriers are pointing away from the extrusion direction.")
+      ->check(CLI::Range(0.0, 1.0))
+      ->capture_default_str();
+
+  barr_adv.add_option(
+      "--extrusion-barrier-bound-stp",
+      c.ctcf_occupied_self_prob,
+      "Self-transition probability for extrusion barriers in the \"bound\" state.\n"
+      "In other words, the probability that an extrusion barrier that is active in the current epoch will remain active during the next epoch.")
+      ->check(CLI::Range(0.0, 1.0));
+
+  barr_adv.add_option(
+      "--extrusion-barrier-not-bound-stp",
+      c.ctcf_not_occupied_self_prob,
+      "Self-transition probability for extrusion barriers in the \"not-bound\" state.\n"
+      "In other words, the probability that an extrusion barrier that is inactive in the current epoch will remain inactive during the next epoch.")
+      ->check(CLI::Range(0.0, 1.0))
+      ->capture_default_str();
+
+  cgen.add_option(
+      "--contact-sampling-strategy",
+      c.contact_sampling_strategy,
+      fmt::format(FMT_STRING("Strategy to use when sampling contacts. Should be one of {}.\n"
+                             "When one of the *-with-noise strategies is specified, contacts are"
+                             "randomized by applying a random offset to the location of LEF extrusion units.\n"
+                             "Offsets are drawn from a genextreme distrubution.\n"
+                             "The distribution parameters can be controlled through the options --mu, --sigma and --xi."),
+                  utils::format_collection_to_english_list(Cli::contact_sampling_strategy_map.keys_view(), ", ", " or ")))
+      ->transform(CLI::CheckedTransformer(Cli::contact_sampling_strategy_map))
+      ->capture_default_str();
+
+  cgen.add_option(
+      "--lef-fraction-for-contact-sampling",
+      c.lef_fraction_contact_sampling,
+      "Fraction of LEFs to use for contact sampling.\n"
+      "The actual number of LEFs to use for contact sampling in a given epoch is drawn from a Poisson distribution "
+      "with lambda=lf*|lefs|, where --lef-fraction-for-contact-sampling=lf and |lefs| is equal to total number of LEFs "
+      "in the current simulation instance.")
+      ->check(CLI::Range(0.0, 1.0))
+      ->capture_default_str();
+
+  cgen.add_option(
+      "-r,--resolution",
       c.bin_size,
-      "Bin size in base pairs.")
+      "Resolution in base-pairs for the output contact matrix in cooler format.\n"
+      "NOTE: MoDLE simulation always take place at 1 bp resolution.\n"
+      "      This parameter only affects the resolution of the output contact matrix.")
       ->check(CLI::PositiveNumber)
       ->transform(utils::str_float_to_str_int)
       ->capture_default_str();
 
-  gen.add_option(
-      "-t,--threads",
-      c.nthreads,
-      "Number of simulate_worker threads used to run the simulation.\n"
-      "By default MoDLE will try to use all available threads.")
-      ->check(CLI::PositiveNumber)
-      ->transform(CLI::Bound(1U, std::thread::hardware_concurrency()))
-      ->capture_default_str();
-
-  gen.add_option(
+  cgen.add_option(
       "-w,--diagonal-width",
       c.diagonal_width,
-      "Diagonal width of the in-memory contact matrix that will be used to store contacts during the simulation.\n"
+      "Width of the subdiagonal window for the in-memory contact matrix.\n"
       "This setting affects the maximum distance of a pair of bins whose interactions will be tracked by MoDLE.\n"
-      "Setting --diagonal-width to a very large value (i.e. more than few Mbp) will dramatically inflate MoDLE's memory footprint.")
+      "As a rule of thumb, --diagonal-width should roughly 10x the average LEF processivity\n."
+      "Setting --diagonal-width to very large values (i.e. tens of Mbp) will significantly increase MoDLE's memory requirements.")
       ->check(CLI::PositiveNumber)
       ->transform(utils::str_float_to_str_int)
       ->capture_default_str();
 
-  gen.add_option(
-      "--target-number-of-epochs",
-      c.target_simulation_epochs,
-      "Number of epochs to simulate for each individual cell.")
-      ->check(CLI::PositiveNumber)
-      ->transform(utils::str_float_to_str_int)
+  cgen_adv.add_option(
+      "--num-of-tad-contacts-per-sampling-event",
+      c.number_of_tad_contacts_per_sampling_event,
+      "Number of TAD contacts to sample each sampling event.\n"
+      "Setting --num-of-tad-contacts-per-sampling-event=0 will yield a contact matrix where contacts are concentrated on stripes and dots.")
       ->capture_default_str();
 
-  gen.add_option(
-      "--target-contact-density",
-      c.target_contact_density,
-      "The average number of contacts to generate for each chromosome before the simulation is halted.")
-      ->check(CLI::NonNegativeNumber);
+  cgen_adv.add_option(
+      "--num-of-loop-contacts-per-sampling-event",
+      c.number_of_loop_contacts_per_sampling_event,
+      "Number of LEF-mediated contacts to sample each sampling event.\n"
+      "Setting --num-of-loop-contacts-per-sampling-event=0 will yield a contact matrix without stripes and dots.")
+      ->capture_default_str();
 
-  gen.add_option(
+  cgen_adv.add_option(
+      "--mu,--genextr-location",
+      c.genextreme_mu,
+      "Location parameter (mu) of the generalized extreme value distribution used to add noise to molecular contacts.")
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  cgen_adv.add_option(
+      "--sigma,--genextr-scale",
+      c.genextreme_sigma,
+      "Scale parameter (sigma) of the generalized extreme value distribution used to add noise to molecular contacts.")
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  cgen_adv.add_option(
+      "--xi,--genextr-shape",
+      c.genextreme_xi,
+      "Shape parameter (xi) of the generalized extreme value distribution used to add noise to molecular contacts.")
+      ->check(CLI::NonNegativeNumber)
+      ->capture_default_str();
+
+  stopping.add_option(
       "-s,--stopping-criterion",
       c.stopping_criterion,
       fmt::format(FMT_STRING("Simulation stopping criterion. Should be one of {}."),
@@ -146,141 +374,51 @@ static void add_common_options(CLI::App& subcommand, modle::Config& c) {
       ->transform(CLI::CheckedTransformer(Cli::stopping_criterion_map))
       ->capture_default_str();
 
-  gen.add_option(
-      "--contact-sampling-strategy",
-      c.contact_sampling_strategy,
-      fmt::format(FMT_STRING("Strategy to use when sampling contacts. Should be one of {}.\n"
-                             "When one of the -with-noise strategy is specified, contacts are"
-                             "randomized by applying a random offset to the location of the extrusion units of LEF.\n"
-                             "Offsets are drawn from a genextreme distrubution.\n"
-                             "The distribution parameters can be controlled through the options --mu, --sigma and --xi."),
-                             utils::format_collection_to_english_list(Cli::contact_sampling_strategy_map.keys_view(), ", ", " or ")))
-            ->transform(CLI::CheckedTransformer(Cli::contact_sampling_strategy_map))
-            ->capture_default_str();
-
-  gen.add_option(
-      "--num-of-tad-contacts-per-sampling-event",
-      c.number_of_tad_contacts_per_sampling_event,
-      "Number of TAD contacts to sample for a LEF that has been selected for contact sampling.")
-      ->capture_default_str();
-
-  gen.add_option(
-      "--num-of-loop-contacts-per-sampling-event",
-      c.number_of_loop_contacts_per_sampling_event,
-      "Number of loop contacts to sample for a LEF that has been selected for contact sampling.")
-      ->capture_default_str();
-
-  gen.add_option(
-      "--lef-density,--lefs-per-mbp",
-      c.number_of_lefs_per_mbp,
-      "Number of loop extrusion factors (LEFs) per Mbp of simulated DNA.")
-      ->check(CLI::NonNegativeNumber)
-      ->capture_default_str();
-
-  gen.add_option(
-      "--hard-stall-lef-stability-multiplier",
-      c.hard_stall_lef_stability_multiplier,
-      "Coefficient to control the DNA-binding stability of LEFs that are stalled on both sides by a pair of "
-      "extrusion barriers in convergent orientation.\n"
-      "Setting this to 1 makes the DNA-binding stability of hard-stalled LEFs identical to that of unobstructed LEFs.")
-      ->check(CLI::NonNegativeNumber)
-      ->capture_default_str();
-
-  gen.add_option(
-      "--soft-stall-lef-stability-multiplier",
-      c.soft_stall_lef_stability_multiplier,
-      "Coefficient to control the DNA-binding stability of a LEF that is stalled by one or more extrusion barriers "
-      "in a non-blocking orientation.\n"
-      "Setting this to 1 makes the DNA-binding stability of soft-stalled LEFs identical to that of unobstructed LEFs.")
-      ->check(CLI::NonNegativeNumber)
-      ->capture_default_str();
-
-  gen.add_option(
-      "--fwd-extrusion-speed",
-      c.fwd_extrusion_speed,
-      "Average distance in bp covered by a LEF in forward direction during one iteration.\n"
-      "By deafult this is set to half of the bin size specified through --bin-size.")
+  stopping.add_option(
+      "--target-number-of-epochs",
+      c.target_simulation_epochs,
+      "Target number of epochs to be simulated.\n"
+      "Each simulation instance will run exactly --target-number-of-epochs epochs after burn-in phase.\n"
+      "Has no effect when --stopping-criterion=\"contact-density\".")
+      ->check(CLI::PositiveNumber)
       ->transform(utils::str_float_to_str_int)
-      ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
-  gen.add_option(
-      "--rev-extrusion-speed",
-      c.rev_extrusion_speed,
-      "Same as --fwd-extrusion-speed but for the reverse direction.")
+  stopping.add_option(
+      "--target-contact-density",
+      c.target_contact_density,
+      "Average contact density to be reached before the simulation is halted.\n"
+      "The target contact density applies independently to each chromosome.\n"
+      "Example: modle sim --chrom-sizes hg38.chr1.chrom.sizes \\\n"
+      "                   --diagonal-width 3000000            \\\n"
+      "                   --resolution 100000                 \\\n"
+      "                   --target-contact-density 2\n"
+      "         Assuming chr1 is exactly 250 Mbp long, MoDLE will schedule simulation instances to yield a total of 150 000 contacts for chr1:\n"
+      "         2 * (250e6 / 100e3) * (3e6 / 100e3) = 150e3.")
+      ->check(CLI::NonNegativeNumber);
+
+  misc.add_option(
+      "--ncells",
+      c.num_cells,
+      "Number of simulation instances or cells to simulate.\n"
+      "Loop extrusion will be simulated independently for every chromosome across --ncells simulation instances.\n"
+      "The final contact matrix is produced by accumulating contacts generated across all simulation instances.\n"
+      "To achieve good performance and CPU utilization we recommend setting --ncells equal to the number of available CPU cores.")
+      ->check(CLI::PositiveNumber)
       ->transform(utils::str_float_to_str_int)
-      ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
-  gen.add_option(
-      "--fwd-extrusion-speed-std",
-      c.fwd_extrusion_speed_std,
-      "Standard deviation of the normal distribution from which LEF forward moves are sampled.\n"
-      "When a number other than 0 is passed to this parameter, the move distribution has mean "
-      "equal to the speed specified through --fwd-extrusion-speed.\n"
-      "Specifying a --fwd-extrusion-speed-std=0 will cause all LEFs to move exactly --fwd-extrusion-speed bp "
-      "at every iteration.\n"
-      "When the specified --fwd-extrusion-speed-std is less than 1, then it will be interpreted as a percentage "
-      "of the forward extrusion speed (i.e. the standard deviation of the distribution will be equal to "
-      "--fwd-extrusion-speed-std * --fwd-extrusion-speed).")
-      ->check(CLI::NonNegativeNumber)
-      ->capture_default_str();
-
-  gen.add_option(
-      "--rev-extrusion-speed-std",
-      c.rev_extrusion_speed_std,
-      "Same as --fwd-extrusion-speed-std but for the reverse direction.")
-      ->check(CLI::NonNegativeNumber)
-      ->capture_default_str();
-
-  gen.add_flag(
-      "--skip-burnin",
-      c.skip_burnin,
-      "Skip the burn-in phase and start counting contacts from the first extrusion round.")
-      ->capture_default_str();
-
-  gen.add_option(
-      "--burnin-target-epochs-for-lef-activation",
-       c.burnin_target_epochs_for_lef_activation,
-      "Number of epochs over which LEFs are progressively activated and bound to DNA.\n"
-      "Note: this number is approximate, as LEFs are activate using a Possion process.\n"
-      "By default this parameter is computed based on the average LEF lifetime, overall extrusion speed "
-      "and burn-in extrusion speed coefficient (controlled by --avg-lef-lifetime, --fwd/rev-extrusion-speed "
-      "and --burn-in-extr-speed-coefficient respectively).")
-       ->check(CLI::PositiveNumber)
-       ->capture_default_str();
-
-  gen.add_option(
-      "--burnin-history-length",
-      c.burnin_history_length,
-      "Number of epochs used to determine whether a simulation instance has reached a stable state.\n"
-      "This is used to decide whether to terminate the burn-in phase at a given epoch.")
+  misc.add_option(
+      "-t,--threads",
+      c.nthreads,
+      "Number of worker threads used to run simulation instances.\n"
+      "By default MoDLE will spawn a number of worker threads equal to the number of logical CPU cores.\n"
+      "Sometimes slightly better performance can be obtained by setting --threads equal to the number of physical CPU cores.\n")
       ->check(CLI::PositiveNumber)
+      ->transform(CLI::Bound(1U, std::thread::hardware_concurrency()))
       ->capture_default_str();
 
-   gen.add_option(
-      "--burnin-smoothing-window-size",
-      c.burnin_smoothing_window_size,
-      "Window size used to smooth values during the burnin phase.")
-      ->check(CLI::PositiveNumber)
-      ->capture_default_str();
-
-  gen.add_option(
-      "--max-burnin-epochs",
-       c.max_burnin_epochs,
-       "Maximum number of epochs to spend in burn-in phase.")
-       ->check(CLI::PositiveNumber)
-       ->capture_default_str();
-
-  gen.add_option(
-      "--burnin-extr-speed-coefficient",
-      c.burnin_speed_coefficient,
-      "Extrusion speed coefficient to apply during the burn-in phase.\n"
-      "Setting this to numbers > 1.0 will speed-up the burn-in phase.")
-      ->check(CLI::PositiveNumber)
-      ->capture_default_str();
-
-  gen.add_option(
+  misc.add_option(
       "--seed",
       c.seed,
       "Base seed to use for random number generation.")
@@ -288,156 +426,72 @@ static void add_common_options(CLI::App& subcommand, modle::Config& c) {
       ->transform(utils::str_float_to_str_int)
       ->capture_default_str();
 
-  gen.add_option(
-      "--avg-lef-processivity",
-      c.avg_lef_processivity,
-      "Average LEF processivity in bp.\n"
-      "The average LEF processivity corresponds to the average size of a loop extruded by an unobstructed LEF.")
+  burnin_adv.add_flag(
+      "--skip-burnin",
+      c.skip_burnin,
+      "Skip the burn-in phase and start collecting contacts from the first extrusion round.")
+      ->capture_default_str();
+
+  burnin_adv.add_option(
+      "--burnin-target-epochs-for-lef-activation",
+       c.burnin_target_epochs_for_lef_activation,
+      "Number of epochs over which LEFs are progressively activated and bound to DNA.\n"
+      "Note: this number is approximate, as LEFs are activated using a Possion process.\n"
+      "By default this parameter is computed based on the average LEF processivity, overall extrusion speed "
+      "and burn-in extrusion speed coefficient (--avg-lef-processivity, --fwd/rev-extrusion-speed "
+      "and --burn-in-extr-speed-coefficient respectively).")
+       ->check(CLI::PositiveNumber)
+       ->capture_default_str();
+
+  burnin_adv.add_option(
+      "--burnin-history-length",
+      c.burnin_history_length,
+      "Number of epochs used to determine whether a simulation instance has reached a stable state.")
       ->check(CLI::PositiveNumber)
       ->capture_default_str();
 
-  prob.add_option(
-      "--probability-of-lef-bypass",
-      c.probability_of_extrusion_unit_bypass,
-      "Probability that two LEFs will bypass each other when meeting.")
-      ->check(CLI::Range(0.0, 1.0))
+  burnin_adv.add_option(
+      "--burnin-smoothing-window-size",
+      c.burnin_smoothing_window_size,
+      "Window size used to smooth metrics monitored to decide when the burn-in phase should be terminated.")
+      ->check(CLI::PositiveNumber)
       ->capture_default_str();
 
-  rand.add_option(
-      "--lef-fraction-for-contact-sampling",
-      c.lef_fraction_contact_sampling,
-      "Fraction of LEFs to use when sampling interactions at every iteration.")
-      ->check(CLI::Range(0.0, 1.0))
+  burnin_adv.add_option(
+      "--max-burnin-epochs",
+       c.max_burnin_epochs,
+       "Upper bound for the burn-in phase duration.\n"
+       "This is especially useful when simlating loop extrusion with very few LEFs.\n"
+       "When this is the case, --max-burnin-epochs=100000 can be used as a very conservative threshold.")
+       ->check(CLI::PositiveNumber)
+       ->capture_default_str();
+
+  burnin_adv.add_option(
+      "--burnin-extr-speed-coefficient",
+      c.burnin_speed_coefficient,
+      "Extrusion speed coefficient to apply during the burn-in phase.\n"
+      "Setting this to numbers > 1.0 will speed-up the burn-in phase, as the average loop size will stabilize faster.\n"
+      "This parameter has many gotchas. For the time being we don't recommend changing this parameter.")
+      ->check(CLI::PositiveNumber)
       ->capture_default_str();
 
-  extr_barr.add_option(
-      "--extrusion-barrier-file",
-      c.path_to_extr_barriers,
-      "Path to BED file containing the extrusion barriers to be used in the simulation.\n"
-      "Barriers corresponding to chromosomes that are not part of the simulation will be ignored.")
-      ->check(CLI::ExistingFile)
-      ->required();
-
-  extr_barr.add_option(
-      "--extrusion-barrier-occupancy",
-      c.extrusion_barrier_occupancy,
-      "Probability that an extrusion barrier will be active (i.e. occupied) at any given time.\n"
-      "This parameter provides an easier mean to set --ctcf-occupied-probability-of-transition-to-self."
-      "Passing this parameter will override barrier occupancies read from the BED file specified through --extrusion-barrier-file.")
-      ->check(CLI::Range(0.0, 1.0));
-
-  extr_barr.add_option(
-      "--lef-bar-major-collision-prob",
-      c.lef_bar_major_collision_pblock,
-      "Collision probability of a LEF moving towards an extrusion barrier in blocking orientation.")
-      ->check(CLI::Range(0.0, 1.0))
-      ->capture_default_str();
-
-  extr_barr.add_option(
-      "--lef-bar-minor-collision-prob",
-      c.lef_bar_minor_collision_pblock,
-      "Collision probability of a LEF moving towards an extrusion barrier in non-blocking orientation.")
-      ->check(CLI::Range(0.0, 1.0))
-      ->capture_default_str();
-
-  extr_barr.add_option(
-      "--ctcf-occupied-probability-of-transition-to-self",
-      c.ctcf_occupied_self_prob,
-      "Probability that an extrusion barrier that was occupied during the previous iteration will also be "
-      "occupied in the current iteration.")
-      ->check(CLI::Range(0.0, 1.0));
-
-  extr_barr.add_option(
-      "--ctcf-not-occupied-probability-of-transition-to-self",
-      c.ctcf_not_occupied_self_prob,
-      "Probability that an extrusion barrier that was not occupied during the previous iteration will remain "
-      "not occupied in the current iteration.")
-      ->check(CLI::Range(0.0, 1.0))
-      ->capture_default_str();
-
-  rand.add_option(
-      "--mu,--genextr-location",
-      c.genextreme_mu,
-      "Location parameter (mu) of the generalized extreme value distribution used to add noise to the contact matrix.")
-      ->check(CLI::NonNegativeNumber)
-      ->capture_default_str();
-
-  rand.add_option(
-      "--sigma,--genextr-scale",
-      c.genextreme_sigma,
-      "Scale parameter (sigma) of the generalized extreme value distribution used to add noise to the contact matrix.")
-      ->check(CLI::NonNegativeNumber)
-      ->capture_default_str();
-
-  rand.add_option(
-      "--xi,--genextr-shape",
-      c.genextreme_xi,
-      "Shape parameter (xi) of the generalized extreme value distribution used to add noise to the contact matrix.")
-      ->check(CLI::NonNegativeNumber)
-      ->capture_default_str();
-
-  dbg.add_flag(
-      "--skip-output",
-      c.skip_output,
-      "Don't write output files. Useful for profiling.")
-      ->capture_default_str();
-
-  gen.get_option("--target-contact-density")->excludes(gen.get_option("--target-number-of-epochs"));
-  extr_barr.get_option("--extrusion-barrier-occupancy")->excludes("--ctcf-occupied-probability-of-transition-to-self");
+  // Address option dependencies/incompatibilities
+  io_adv.get_option("--skip-output")->excludes(io_adv.get_option("--log-model-internal-state"));
+  stopping.get_option("--target-contact-density")->excludes(stopping.get_option("--target-number-of-epochs"));
+  lefbar.get_option("--extrusion-barrier-occupancy")->excludes(barr_adv.get_option("--extrusion-barrier-bound-stp"));
   // clang-format on
 }
 
 void Cli::make_simulation_subcommand() {
-  auto& s = *this->_cli
-                 .add_subcommand("simulate",
-                                 "Perform a single genome-wide simulation and output the resulting "
-                                 "contacts to a .cool file.")
-                 ->fallthrough()
-                 ->configurable();
+  auto& s =
+      *this->_cli
+           .add_subcommand(
+               "simulate",
+               "Simulate loop extrusion and write resulting molecular contacts in a .cool file.")
+           ->fallthrough()
+           ->configurable();
   s.alias("sim");
   add_common_options(s, this->_config);
-
-  auto& c = this->_config;
-  auto& io = *s.get_option_group("Input/Output");
-  auto& gen = *s.get_option_group("Generic");
-  auto& dbg = *s.add_option_group("Debug/Profiling", "");
-
-  // clang-format off
-  io.add_option(
-      "-o,--output-prefix",
-      c.path_to_output_prefix,
-      "Output prefix. Can be a full or relative path including the file name but without file extension.\n"
-      "Example: -o /tmp/mymatrix will cause MoDLE to write contacts to a file named \"/tmp/mymatrix.cool\", "
-      "while a log file will be saved at \"/tmp/mymatrix.log\".")
-      ->required();
-
-  io.add_flag(
-      "--write-contacts-for-excluded-chroms",
-      c.write_contacts_for_ko_chroms,
-      "Write contacts for all chromosomes, even those where loop extrusion was not simulated.\n"
-      "In the latter case MoDLE will only write to the chrom, bins and indexes datasets to the contact matrix.")
-      ->capture_default_str();
-
-  gen.add_option(
-      "--ncells",
-      c.num_cells,
-      "Number of cells to simulate.\n"
-      "Loop extrusion will be simulated independently on each chromosome across --ncells simulation instances.\n"
-      "The total number of contacts for a given chromosome is obtained by aggregating contacts from all the "
-      "simulation instances for that chromosome.")
-      ->check(CLI::PositiveNumber)
-      ->transform(utils::str_float_to_str_int)
-      ->capture_default_str();
-
-  dbg.add_flag(
-      "--log-model-internal-state",
-      c.log_model_internal_state,
-      "Produce a detailed log of the model internal state throughout a simulation.\n"
-      "Passing this flag often causes a noticeable reduction in MoDLE's throughput.")
-      ->capture_default_str();
-
-  s.get_option_group("Debug/Profiling")->get_option("--skip-output")->excludes(dbg.get_option("--log-model-internal-state"));
-  // clang-format on
 }
 
 void Cli::make_perturbate_subcommand() {
@@ -453,27 +507,34 @@ void Cli::make_perturbate_subcommand() {
   add_common_options(s, this->_config);
 
   auto& c = this->_config;
-  auto& io = *s.get_option_group("Input/Output");
-  auto& gen = *s.get_option_group("Generic");
+  auto& io = *s.get_option_group("IO");
+  auto& misc = *s.get_option_group("Miscellaneous");
 
+  auto& io_adv = *s.get_option_group("Advanced/IO");
 
+  // Remove unused flags/options
+  io_adv.remove_option(io_adv.get_option("--simulate-chromosomes-wo-barriers"));
+  misc.remove_option(misc.get_option("--ncells"));
+
+  // Update flag/option descriptions
   // clang-format off
-  io.add_option(
-      "-o,--output-prefix",
-      c.path_to_output_prefix,
-      "Output prefix. Can be a full or relative path including the file name but without file extension.\n"
-      "Example: -o /tmp/mycontacts will cause MoDLE to write interactions to a file named \"/tmp/mycontacts.bedpe.gz\", "
-      "while a log file will be saved at \"/tmp/mycontacts.log\".")
-      ->required();
+  io.get_option("--output-prefix")
+      ->description(
+      "Output prefix.\n"
+      "Can be a full or relative path including the file name but without extension.\n"
+      "Example: -o /tmp/mymatrix will produce the following files:\n"
+      "         - /tmp/mymatrix.bedpe.gz\n"
+      "         - /tmp/mymatrix.log\n");
 
+  // Add new flags/options
   io.add_option(
       "--reference-contacts",
       c.path_to_reference_contacts,
-      "Path to a Cooler file with the contact matrix to use as reference")
+      "Path to a cooler file with the contact matrix to use as reference")
       ->check(CLI::ExistingFile)
       ->required();
 
-  io.add_flag("--write-header,!--no-write-header",
+  io_adv.add_flag("--write-header,!--no-write-header",
       c.write_header,
       "Write header with column names to output file.")
       ->capture_default_str();
@@ -486,14 +547,14 @@ void Cli::make_perturbate_subcommand() {
       "When a single BED file is specified, the output will only contain within-feature contacts (Not yet implemented).")
       ->check(CLI::ExistingFile);
 
-  gen.add_flag(
+  io_adv.add_flag(
       "--generate-reference-matrix",
       c.compute_reference_matrix,
       "Compute and write to disk the reference contact matrix."
       "This is equivalent to running modle simulate followed by modle perturbate without changing parameters.")
       ->capture_default_str();
 
-  gen.add_option(
+  misc.add_option(
       "--block-size",
       c.block_size,
       "Size of the block of pixels to use when generating contacts for a pair of features. Must be an odd number.")
@@ -502,7 +563,7 @@ void Cli::make_perturbate_subcommand() {
       ->transform(utils::str_float_to_str_int)
       ->capture_default_str();
 
-  gen.add_option(
+  misc.add_option(
       "--deletion-size",
       c.deletion_size,
       "Size of deletion in bp. Used to enable/disable extrusion barriers and compute the total number of contacts between pairs of feats1.\n"
@@ -511,15 +572,14 @@ void Cli::make_perturbate_subcommand() {
       ->transform(utils::str_float_to_str_int)
       ->capture_default_str();
 
-  gen.add_option(
+  misc.add_option(
       "--deletion-list",
       c.path_to_deletion_bed,
       "Path to a BED file containing the list deletions to perform when perturbating extrusion barriers.")
       ->check(CLI::ExistingFile);
   // clang-format on
 
-  gen.get_option("--deletion-size")->excludes("--deletion-list");
-  gen.get_option("--deletion-list")->excludes("--deletion-size");
+  misc.get_option("--deletion-size")->excludes("--deletion-list");
 }
 
 void Cli::make_replay_subcommand() {
@@ -532,8 +592,8 @@ void Cli::make_replay_subcommand() {
   s.alias("rpl");
 
   auto& c = this->_config;
-  auto& io = *s.add_option_group("Input/Output", "");
-  auto& gen = *s.add_option_group("Generic", "");
+  auto& io = *s.add_option_group("IO", "Options controlling MoDLE input, output and logs.");
+  auto& various = *s.add_option_group("Various");
 
   // clang-format off
   io.add_option(
@@ -559,7 +619,8 @@ void Cli::make_replay_subcommand() {
   io.add_option(
       "-o,--output-prefix",
       c.path_to_output_prefix,
-      "Output prefix. Can be a full or relative path including the file name but without file extension.")
+      "Output prefix.\n"
+      "Can be a full or relative path including the file name but without extension.")
       ->required();
 
   io.add_flag(
@@ -568,7 +629,7 @@ void Cli::make_replay_subcommand() {
       "Force overwrite of output files if they exists.")
       ->capture_default_str();
 
-  gen.add_option(
+  various.add_option(
       "-t,--threads",
       c.nthreads,
       "Number of simulate_worker threads used to run the simulation.\n"
@@ -580,7 +641,8 @@ void Cli::make_replay_subcommand() {
 }
 
 void Cli::make_cli() {
-  this->_cli.description("Stochastic modeling of DNA loop extrusion.");
+  this->_cli.description(
+      "High-performance stochastic modeling of DNA loop extrusion interactions.");
   this->_cli.set_version_flag("-V,--version", std::string{modle::config::version::str_long()});
   this->_cli.require_subcommand(1);
   this->_cli.set_config("--config", "", "Path to MoDLE's config file (optional).", false);
@@ -593,7 +655,6 @@ void Cli::make_cli() {
 Cli::Cli(int argc, char** argv) : _argc(argc), _argv(argv), _exec_name(*argv) { this->make_cli(); }
 
 const Config& Cli::parse_arguments() {
-  using namespace std::string_view_literals;
   if (this->_cli.parsed()) {
     return this->_config;
   }
@@ -604,15 +665,15 @@ const Config& Cli::parse_arguments() {
   if (this->_cli.get_subcommand("simulate")->parsed()) {
     this->_subcommand = simulate;
   } else if (this->_cli.get_subcommand("perturbate")->parsed()) {
-    this->_subcommand = pertubate;
+    this->_subcommand = perturbate;
   } else {
     assert(this->_cli.get_subcommand("replay")->parsed());
     this->_subcommand = replay;
     // The code in this branch basically tricks CLI11 into parsing a config file by creating a fake
     // argv like: {"modle", "pert", "--config", "myconfig.toml"}
     const auto config_backup = this->_config;
-    constexpr std::string_view subcmd_arg = "pert\0"sv;
-    constexpr std::string_view config_arg = "--config\0"sv;
+    constexpr std::string_view subcmd_arg = "pert\0";
+    constexpr std::string_view config_arg = "--config\0";
     const std::array<const char*, 4> args{this->_exec_name.c_str(), subcmd_arg.data(),
                                           config_arg.data(),
                                           this->_config.path_to_config_file.c_str()};
@@ -680,18 +741,18 @@ std::string Cli::detect_path_collisions(modle::Config& c) const {
     absl::StrAppend(&collisions, check_for_path_collisions(c.path_to_config_file));
   }
   if ((this->get_subcommand() == subcommand::simulate ||
-       (this->get_subcommand() == subcommand::pertubate &&
+       (this->get_subcommand() == subcommand::perturbate &&
         this->_config.compute_reference_matrix)) &&
       boost::filesystem::exists(c.path_to_output_file_cool)) {
     absl::StrAppend(&collisions, check_for_path_collisions(c.path_to_output_file_cool));
   }
-  if ((this->get_subcommand() == subcommand::pertubate ||
+  if ((this->get_subcommand() == subcommand::perturbate ||
        this->get_subcommand() == subcommand::replay) &&
       !c.path_to_output_file_bedpe.empty() &&
       boost::filesystem::exists(c.path_to_output_file_bedpe)) {
     absl::StrAppend(&collisions, check_for_path_collisions(c.path_to_output_file_bedpe));
   }
-  if (this->get_subcommand() == subcommand::pertubate &&
+  if (this->get_subcommand() == subcommand::perturbate &&
       boost::filesystem::exists(this->_config.path_to_task_file)) {
     absl::StrAppend(&collisions, check_for_path_collisions(c.path_to_task_file));
   }
@@ -708,8 +769,9 @@ void Cli::validate_args() const {
   const auto* subcmd = this->get_subcommand_ptr();
 
   if (c.burnin_smoothing_window_size > c.burnin_history_length) {
-    assert(subcmd->get_option_group("Generic")->get_option("--burnin-smoothing-window-size"));
-    assert(subcmd->get_option_group("Generic")->get_option("--burnin-history-length"));
+    assert(
+        subcmd->get_option_group("Advanced/Burn-in")->get_option("--burnin-smoothing-window-size"));
+    assert(subcmd->get_option_group("Advanced/Burn-in")->get_option("--burnin-history-length"));
     errors.emplace_back(fmt::format(
         FMT_STRING("The value passed to {} should be less or equal than that of {} ({} > {})"),
         "--burnin-smoothing-window-size", "--burnin-history-length", c.burnin_smoothing_window_size,
@@ -727,7 +789,7 @@ void Cli::validate_args() const {
 
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)
   if (!(c.contact_sampling_strategy & Config::ContactSamplingStrategy::noisify)) {
-    const auto& group = subcmd->get_option_group("Random");
+    const auto& group = subcmd->get_option_group("Advanced/Contact generation");
     for (const std::string label : {"--mu", "--sigma", "--xi"}) {
       if (!group->get_option(label)->empty()) {
         errors.emplace_back(fmt::format(FMT_STRING("Option {} requires the strategy passed to "
@@ -740,7 +802,7 @@ void Cli::validate_args() const {
 
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)
   if (c.contact_sampling_strategy & Config::ContactSamplingStrategy::tad &&
-      !subcmd->get_option_group("Generic")
+      !subcmd->get_option_group("Advanced/Contact generation")
            ->get_option("--num-of-tad-contacts-per-sampling-event")
            ->empty()) {
     errors.emplace_back(
@@ -750,13 +812,24 @@ void Cli::validate_args() const {
 
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)
   if (c.contact_sampling_strategy & Config::ContactSamplingStrategy::loop &&
-      !subcmd->get_option_group("Generic")
+      !subcmd->get_option_group("Advanced/Contact generation")
            ->get_option("--num-of-loop-contacts-per-sampling-event")
            ->empty()) {
     errors.emplace_back(
         "--num-of-loop-contacts-per-sampling-event is not allowed when the sampling strategy "
-        "passed "
-        "through --contact-sampling-strategy does not involve sampling contacts from loops.");
+        "passed through --contact-sampling-strategy does not involve sampling contacts from "
+        "loops.");
+  }
+
+  if (c.number_of_tad_contacts_per_sampling_event + c.number_of_loop_contacts_per_sampling_event ==
+      0) {
+    // clang-format off
+    assert(subcmd->get_option_group("Advanced/Contact generation")->get_option("--num-of-tad-contacts-per-sampling-event"));
+    assert(subcmd->get_option_group("Advanced/Contact generation")->get_option("--num-of-loop-contacts-per-sampling-event"));
+    // clang-format on
+    errors.emplace_back(
+        "--num-of-tad-contacts-per-sampling-event and --num-of-loop-contacts-per-sampling-event "
+        "cannot both be set to zero.");
   }
 
   if (!errors.empty()) {
@@ -794,13 +867,13 @@ void Cli::transform_args() {
       !c.path_to_feature_bed_files.empty() ? c.path_to_output_prefix : boost::filesystem::path{};
   c.path_to_log_file = c.path_to_output_prefix;
   c.path_to_config_file = c.path_to_output_prefix;
-  if (this->get_subcommand() == subcommand::pertubate) {
+  if (this->get_subcommand() == subcommand::perturbate) {
     c.path_to_task_file = c.path_to_output_prefix;
     c.path_to_task_file += "_tasks.tsv.gz";
   }
   if (this->get_subcommand() == subcommand::simulate) {
     c.path_to_model_state_log_file = c.path_to_output_prefix;
-    c.path_to_model_state_log_file += "_internal_state_log.tsv.gz";
+    c.path_to_model_state_log_file += "_internal_state.log.gz";
   }
 
   c.path_to_output_file_cool += ".cool";
@@ -810,10 +883,10 @@ void Cli::transform_args() {
 
   // Compute mean and std for rev and fwd extrusion speed
   if (auto& speed = c.rev_extrusion_speed; speed == (std::numeric_limits<bp_t>::max)()) {
-    speed = static_cast<bp_t>(std::round(static_cast<double>(c.bin_size) / 2.0));
+    speed = (c.bin_size + 1) / 2;
   }
   if (auto& speed = c.fwd_extrusion_speed; speed == (std::numeric_limits<bp_t>::max)()) {
-    speed = static_cast<bp_t>(std::round(static_cast<double>(c.bin_size) / 2.0));
+    speed = (c.bin_size + 1) / 2;
   }
 
   if (auto& stddev = c.fwd_extrusion_speed_std; stddev > 0 && stddev < 1) {
@@ -849,7 +922,7 @@ void Cli::transform_args() {
 
   const auto* subcmd = this->get_subcommand_ptr();
 
-  if (!subcmd->get_option_group("Extrusion Barriers")
+  if (!subcmd->get_option_group("Extrusion Barriers and Factors")
            ->get_option("--extrusion-barrier-occupancy")
            ->empty()) {
     c.override_extrusion_barrier_occupancy = true;

--- a/src/modle/cli.cpp
+++ b/src/modle/cli.cpp
@@ -62,7 +62,7 @@ std::ostream& operator<<(std::ostream& os, const Config::ContactSamplingStrategy
   return os;
 }
 
-static void add_common_options(CLI::App& subcommand, modle::Config& config) {
+static std::vector<CLI::App*> add_common_options(CLI::App& subcommand, modle::Config& config) {
   auto& s = subcommand;
   auto& c = config;
 
@@ -112,9 +112,12 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
   io.add_option(
       "-b,--extrusion-barrier-file",
       c.path_to_extr_barriers,
-      "Path to a file in BED6+ format with the genomic coordinates of extrusion barriers to be simulated.\n"
-      "The score field in a BED record should be a number between 0 and 1 and is interpreted as the extrusion barrier occupancy for the extrusion barrier described by the record.\n"
-      "Barriers mapping on chromosomes not listed in the chrom.sizes file passed through the --chrom-sizes option are ignored.")
+      "Path to a file in BED6+ format with the genomic coordinates of extrusion barriers to be\n"
+      "simulated. The score field in a BED record should be a number between 0 and 1 and is\n"
+      "interpreted as the extrusion barrier occupancy for the extrusion barrier described\n"
+      "by the record.\n"
+      "Barriers mapping on chromosomes not listed in the chrom.sizes file passed through\n"
+      "the --chrom-sizes option are ignored.")
       ->check(CLI::ExistingFile)
       ->required();
 
@@ -148,10 +151,12 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       c.log_model_internal_state,
       fmt::format(FMT_STRING(
                       "Collect detailed statistics regarding the internal state of MoDLE simulation instance(s).\n"
-                      "Statistics will be written to a compressed file under the prefix specified through the --output-prefix option.\n"
-                      "Example: with --output-prefix=/tmp/myprefix, statistics will be written to file /tmp/myprefix_internal_state.log.gz.\n"
-                      "Depending on the input file(s) and parameters, specifying this option may hinder simulation throughput.\n"
-                      "Currently the following metrics are collected:\n"
+                      "Statistics will be written to a compressed file under the prefix specified through the\n"
+                      "--output-prefix option.\n"
+                      "Example: modle sim --output-prefix=/tmp/myprefix\n"
+                               "statistics will be written to file /tmp/myprefix_internal_state.log.gz.\n"
+                      "Depending on the input file(s) and parameters, specifying this option may hinder\n"
+                      "simulation throughput. Currently the following metrics are collected:\n"
                       " - {}"),
                   fmt::join(absl::StrSplit(Config::model_internal_state_log_header, '\t'), "\n - ")))
       ->capture_default_str();
@@ -160,8 +165,9 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "--simulate-chromosomes-wo-barriers,!--skip-chromosomes-wo-barriers",
       c.simulate_chromosomes_wo_barriers,
       "Enable/disable simulation of loop extrusion for chromosomes with 0 extrusion barriers.\n"
-      "When --skip-chromosomes-wo-barriers is passed, entries for chromosomes without barriers will "
-      "still be written to the output .cool file, but no contacts will be generated for those chromosomes.")
+      "When --skip-chromosomes-wo-barriers is passed, entries for chromosomes without barriers\n"
+      "will still be written to the output .cool file, but no contacts will be generated for\n"
+      "those chromosomes.")
       ->capture_default_str();
 
   io_adv.add_flag(
@@ -181,7 +187,8 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "--avg-lef-processivity",
       c.avg_lef_processivity,
       "Average LEF processivity in bp.\n"
-      "The average LEF processivity corresponds to the average size of loops extruded by unobstructed LEFs.")
+      "The average LEF processivity corresponds to the average size of loops extruded by\n"
+      "unobstructed LEFs.")
       ->check(CLI::PositiveNumber)
       ->capture_default_str();
 
@@ -197,25 +204,26 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       c.extrusion_barrier_occupancy,
       "Probability that an extrusion barrier is occupied (i.e. blocking) at any given time.\n"
       "This parameter provides an easier mean to set --extrusion-barrier-bound-stp.\n"
-      "Passing this parameter will override barrier occupancies read from the BED file specified through --extrusion-barrier-file.")
+      "Passing this parameter will override barrier occupancies read from the BED file specified\n"
+      "through --extrusion-barrier-file.")
       ->check(CLI::Range(0.0, 1.0));
 
   lef_adv.add_option(
       "--hard-stall-lef-stability-multiplier",
       c.hard_stall_lef_stability_multiplier,
-      "Coefficient to control the DNA-binding stability of LEFs that are stalled on both sides by a pair of "
-      "extrusion barriers in convergent orientation.\n"
-      "Setting this to 1 makes the DNA-binding stability of hard-stalled LEFs identical to that of unobstructed LEFs.\n"
-      "Has no effects when --lef-bar-major-collision-prob=0.")
+      "Coefficient to control the DNA-binding stability of LEFs that are stalled on both sides by a\n"
+      "pair of extrusion barriers in convergent orientation.\n"
+      "Setting this to 1 makes the DNA-binding stability of hard-stalled LEFs identical to that of\n"
+      "unobstructed LEFs. Has no effects when --lef-bar-major-collision-prob=0.")
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
   lef_adv.add_option(
       "--soft-stall-lef-stability-multiplier",
       c.soft_stall_lef_stability_multiplier,
-      "Coefficient to control the DNA-binding stability of LEFs stalled by one or more extrusion barriers "
-      "in a non-blocking orientation.\n"
-      "Setting this to 1 makes the DNA-binding stability of soft-stalled LEFs identical to that of unobstructed LEFs.\n"
+      "Coefficient to control the DNA-binding stability of LEFs stalled by one or more extrusion\n"
+      "barriers in a non-blocking orientation. Setting this to 1 makes the DNA-binding stability\n"
+      "of soft-stalled LEFs identical to that of unobstructed LEFs.\n"
       "Has no effects when --lef-bar-minor-collision-prob=0.")
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
@@ -225,10 +233,12 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       c.fwd_extrusion_speed,
       "Average extrusion speed expressed in bp/epoch for forward-moving extrusion units.\n"
       "Extrusion units are assigned a candidate moving distance at the beginning of every epoch.\n"
-      "Moves are sampled from a normal distribution centered around --fwd-extrusion-speed and with --fwd-extrusion-speed-std as its standard deviation.\n"
-      "Candidate moves represent the maximum distance a given extrusion unit is set to travel during the current epoch.\n"
+      "Moves are sampled from a normal distribution centered around --fwd-extrusion-speed and with\n"
+      "--fwd-extrusion-speed-std as its standard deviation. Candidate moves represent the maximum\n"
+      "distance a given extrusion unit is set to travel during the current epoch.\n"
       "Moving distances can be shortened by collision events taking place during the current epoch.\n"
-      "By deafult extrusion speed is set to half the bin size specified through the --resolution option.")
+      "By deafult extrusion speed is set to half the bin size specified through the --resolution\n"
+      "option.")
       ->transform(utils::str_float_to_str_int)
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
@@ -244,10 +254,12 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
   lef_adv.add_option(
       "--fwd-extrusion-speed-std",
       c.fwd_extrusion_speed_std,
-      "Standard deviation of the normal distribution used to sample candidate moves for extrusion units moving in 5'-3' direction.\n"
-      "See help message for --fwd-extrusion-speed for more details regarding candidate moves.\n"
+      "Standard deviation of the normal distribution used to sample candidate moves for extrusion\n"
+      "units moving in 5'-3' direction. See help message for --fwd-extrusion-speed for more details\n"
+      "regarding candidate moves.\n"
       "Specifying --fwd-extrusion-speed-std=0 will make candidate moves deterministic.\n"
-      "Standard deviations between 0 and 1 are interpreted a percentage of the average extrusion speed.\n"
+      "Standard deviations between 0 and 1 are interpreted a percentage of the average extrusion\n"
+      "speed.\n"
       "Example: when running modle sim --fwd-extrusion-speed=10000 ...\n"
       "         --fwd-extrusion-speed-std=0.1 and --fwd-extrusion-speed-std=1000 are equivalent.")
       ->check(CLI::NonNegativeNumber)
@@ -263,14 +275,16 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
   barr_adv.add_option(
       "--lef-bar-major-collision-prob",
       c.lef_bar_major_collision_pblock,
-      "Probability of collision between LEFs and extrusion barriers where barriers are pointing towards the extrusion direction.")
+      "Probability of collision between LEFs and extrusion barriers where barriers are pointing\n"
+      "towards the extrusion direction.")
       ->check(CLI::Range(0.0, 1.0))
       ->capture_default_str();
 
   barr_adv.add_option(
       "--lef-bar-minor-collision-prob",
       c.lef_bar_minor_collision_pblock,
-      "Probability of collision between LEFs and extrusion barriers where barriers are pointing away from the extrusion direction.")
+      "Probability of collision between LEFs and extrusion barriers where barriers are pointing\n"
+      "away from the extrusion direction.")
       ->check(CLI::Range(0.0, 1.0))
       ->capture_default_str();
 
@@ -278,26 +292,31 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "--extrusion-barrier-bound-stp",
       c.ctcf_occupied_self_prob,
       "Self-transition probability for extrusion barriers in the \"bound\" state.\n"
-      "In other words, the probability that an extrusion barrier that is active in the current epoch will remain active during the next epoch.")
+      "In other words, the probability that an extrusion barrier that is active in the current epoch\n"
+      "will remain active during the next epoch.")
       ->check(CLI::Range(0.0, 1.0));
 
   barr_adv.add_option(
       "--extrusion-barrier-not-bound-stp",
       c.ctcf_not_occupied_self_prob,
       "Self-transition probability for extrusion barriers in the \"not-bound\" state.\n"
-      "In other words, the probability that an extrusion barrier that is inactive in the current epoch will remain inactive during the next epoch.")
+      "In other words, the probability that an extrusion barrier that is inactive in the current\n"
+      "epoch will remain inactive during the next epoch.")
       ->check(CLI::Range(0.0, 1.0))
       ->capture_default_str();
 
   cgen.add_option(
       "--contact-sampling-strategy",
       c.contact_sampling_strategy,
-      fmt::format(FMT_STRING("Strategy to use when sampling contacts. Should be one of {}.\n"
-                             "When one of the *-with-noise strategies is specified, contacts are"
-                             "randomized by applying a random offset to the location of LEF extrusion units.\n"
+      fmt::format(FMT_STRING("Strategy to use when sampling contacts.\n"
+                             "Should be one of:\n"
+                             "- {}\n"
+                             "When one of the *-with-noise strategies is specified, contacts are randomized by\n"
+                             "applying a random offset to the location of LEF extrusion units.\n"
                              "Offsets are drawn from a genextreme distrubution.\n"
-                             "The distribution parameters can be controlled through the options --mu, --sigma and --xi."),
-                  utils::format_collection_to_english_list(Cli::contact_sampling_strategy_map.keys_view(), ", ", " or ")))
+                             "The distribution parameters can be controlled through the options --mu, --sigma\n"
+                             "and --xi."),
+                  fmt::join(Cli::contact_sampling_strategy_map.keys_view(), "\n - ")))
       ->transform(CLI::CheckedTransformer(Cli::contact_sampling_strategy_map))
       ->capture_default_str();
 
@@ -305,9 +324,9 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "--lef-fraction-for-contact-sampling",
       c.lef_fraction_contact_sampling,
       "Fraction of LEFs to use for contact sampling.\n"
-      "The actual number of LEFs to use for contact sampling in a given epoch is drawn from a Poisson distribution "
-      "with lambda=lf*|lefs|, where --lef-fraction-for-contact-sampling=lf and |lefs| is equal to total number of LEFs "
-      "in the current simulation instance.")
+      "The actual number of LEFs to use for contact sampling in a given epoch is drawn from a\n"
+      "Poisson distribution with lambda=lf*|lefs|, where --lef-fraction-for-contact-sampling=lf\n"
+      "and |lefs| is equal to total number of LEFs in the current simulation instance.")
       ->check(CLI::Range(0.0, 1.0))
       ->capture_default_str();
 
@@ -325,9 +344,11 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "-w,--diagonal-width",
       c.diagonal_width,
       "Width of the subdiagonal window for the in-memory contact matrix.\n"
-      "This setting affects the maximum distance of a pair of bins whose interactions will be tracked by MoDLE.\n"
+      "This setting affects the maximum distance of a pair of bins whose interactions will be\n"
+      "tracked by MoDLE.\n"
       "As a rule of thumb, --diagonal-width should roughly 10x the average LEF processivity\n."
-      "Setting --diagonal-width to very large values (i.e. tens of Mbp) will significantly increase MoDLE's memory requirements.")
+      "Setting --diagonal-width to very large values (i.e. tens of Mbp) will significantly\n"
+      "increase MoDLE's memory requirements.")
       ->check(CLI::PositiveNumber)
       ->transform(utils::str_float_to_str_int)
       ->capture_default_str();
@@ -336,34 +357,39 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "--num-of-tad-contacts-per-sampling-event",
       c.number_of_tad_contacts_per_sampling_event,
       "Number of TAD contacts to sample each sampling event.\n"
-      "Setting --num-of-tad-contacts-per-sampling-event=0 will yield a contact matrix where contacts are concentrated on stripes and dots.")
+      "Setting --num-of-tad-contacts-per-sampling-event=0 will yield a contact matrix where\n"
+      "contacts are concentrated on stripes and dots.")
       ->capture_default_str();
 
   cgen_adv.add_option(
       "--num-of-loop-contacts-per-sampling-event",
       c.number_of_loop_contacts_per_sampling_event,
       "Number of LEF-mediated contacts to sample each sampling event.\n"
-      "Setting --num-of-loop-contacts-per-sampling-event=0 will yield a contact matrix without stripes and dots.")
+      "Setting --num-of-loop-contacts-per-sampling-event=0 will yield a contact matrix without\n"
+      "stripes and dots.")
       ->capture_default_str();
 
   cgen_adv.add_option(
       "--mu,--genextr-location",
       c.genextreme_mu,
-      "Location parameter (mu) of the generalized extreme value distribution used to add noise to molecular contacts.")
+      "Location parameter (mu) of the generalized extreme value distribution used to add noise to\n"
+      "molecular contacts.")
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
   cgen_adv.add_option(
       "--sigma,--genextr-scale",
       c.genextreme_sigma,
-      "Scale parameter (sigma) of the generalized extreme value distribution used to add noise to molecular contacts.")
+      "Scale parameter (sigma) of the generalized extreme value distribution used to add noise to\n"
+      "molecular contacts.")
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
   cgen_adv.add_option(
       "--xi,--genextr-shape",
       c.genextreme_xi,
-      "Shape parameter (xi) of the generalized extreme value distribution used to add noise to molecular contacts.")
+      "Shape parameter (xi) of the generalized extreme value distribution used to add noise to\n"
+      "molecular contacts.")
       ->check(CLI::NonNegativeNumber)
       ->capture_default_str();
 
@@ -379,8 +405,8 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "--target-number-of-epochs",
       c.target_simulation_epochs,
       "Target number of epochs to be simulated.\n"
-      "Each simulation instance will run exactly --target-number-of-epochs epochs after burn-in phase.\n"
-      "Has no effect when --stopping-criterion=\"contact-density\".")
+      "Each simulation instance will run exactly --target-number-of-epochs epochs after burn-in\n"
+      "phase. Has no effect when --stopping-criterion=\"contact-density\".")
       ->check(CLI::PositiveNumber)
       ->transform(utils::str_float_to_str_int)
       ->capture_default_str();
@@ -394,17 +420,18 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "                   --diagonal-width 3000000            \\\n"
       "                   --resolution 100000                 \\\n"
       "                   --target-contact-density 2\n"
-      "         Assuming chr1 is exactly 250 Mbp long, MoDLE will schedule simulation instances to yield a total of 150 000 contacts for chr1:\n"
-      "         2 * (250e6 / 100e3) * (3e6 / 100e3) = 150e3.")
+      "         Assuming chr1 is exactly 250 Mbp long, MoDLE will schedule simulation instances to yield\n"
+      "         a total of 150 000 contacts for chr1: 2 * (250e6 / 100e3) * (3e6 / 100e3) = 150e3.")
       ->check(CLI::PositiveNumber);
 
   misc.add_option(
       "--ncells",
       c.num_cells,
       "Number of simulation instances or cells to simulate.\n"
-      "Loop extrusion will be simulated independently for every chromosome across --ncells simulation instances.\n"
-      "The final contact matrix is produced by accumulating contacts generated across all simulation instances.\n"
-      "To achieve good performance and CPU utilization we recommend setting --ncells equal to the number of available CPU cores.")
+      "Loop extrusion will be simulated independently for every chromosome across --ncells\n"
+      "simulation instances. The final contact matrix is produced by accumulating contacts\n"
+      "generated across all simulation instances. To achieve good performance and CPU utilization\n"
+      "we recommend setting --ncells equal to the number of available CPU cores.")
       ->check(CLI::PositiveNumber)
       ->transform(utils::str_float_to_str_int)
       ->capture_default_str();
@@ -413,8 +440,9 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "-t,--threads",
       c.nthreads,
       "Number of worker threads used to run simulation instances.\n"
-      "By default MoDLE will spawn a number of worker threads equal to the number of logical CPU cores.\n"
-      "Sometimes slightly better performance can be obtained by setting --threads equal to the number of physical CPU cores.\n")
+      "By default MoDLE will spawn a number of worker threads equal to the number of logical CPU\n"
+      "cores. On high core count machines a slightly better performance can usually be obtained\n"
+      "by setting --threads equal to the number of physical CPU cores.\n")
       ->check(CLI::PositiveNumber)
       ->transform(CLI::Bound(1U, std::thread::hardware_concurrency()))
       ->capture_default_str();
@@ -438,9 +466,9 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
        c.burnin_target_epochs_for_lef_activation,
       "Number of epochs over which LEFs are progressively activated and bound to DNA.\n"
       "Note: this number is approximate, as LEFs are activated using a Possion process.\n"
-      "By default this parameter is computed based on the average LEF processivity, overall extrusion speed "
-      "and burn-in extrusion speed coefficient (--avg-lef-processivity, --fwd/rev-extrusion-speed "
-      "and --burn-in-extr-speed-coefficient respectively).")
+      "By default this parameter is computed based on the average LEF processivity, overall\n"
+      "extrusion speed and burn-in extrusion speed coefficient (--avg-lef-processivity,\n"
+      "--fwd/rev-extrusion-speed and --burn-in-extr-speed-coefficient respectively).")
        ->check(CLI::PositiveNumber)
        ->capture_default_str();
 
@@ -454,7 +482,8 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
   burnin_adv.add_option(
       "--burnin-smoothing-window-size",
       c.burnin_smoothing_window_size,
-      "Window size used to smooth metrics monitored to decide when the burn-in phase should be terminated.")
+      "Window size used to smooth metrics monitored to decide when the burn-in phase should be\n"
+      "terminated.")
       ->check(CLI::PositiveNumber)
       ->capture_default_str();
 
@@ -463,16 +492,19 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
        c.max_burnin_epochs,
        "Upper bound for the burn-in phase duration.\n"
        "This is especially useful when simlating loop extrusion with very few LEFs.\n"
-       "When this is the case, --max-burnin-epochs=100000 can be used as a very conservative threshold.")
+       "When this is the case, --max-burnin-epochs=100000 can be used as a very conservative\n"
+       "threshold.")
        ->check(CLI::PositiveNumber)
-       ->capture_default_str();
+       ->default_str("inf");
 
   burnin_adv.add_option(
       "--burnin-extr-speed-coefficient",
       c.burnin_speed_coefficient,
       "Extrusion speed coefficient to apply during the burn-in phase.\n"
-      "Setting this to numbers > 1.0 will speed-up the burn-in phase, as the average loop size will stabilize faster.\n"
-      "This parameter has many gotchas. For the time being we don't recommend changing this parameter.")
+      "Setting this to numbers > 1.0 will speed-up the burn-in phase, as the average loop size will\n"
+      "stabilize faster.\n"
+      "IMPORTANT: Setting this parameter to values other than 1.0 comes with many gotchas.\n"
+      "           For the time being, tuning this parameter is not reccommended.")
       ->check(CLI::PositiveNumber)
       ->capture_default_str();
 
@@ -481,6 +513,14 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
   stopping.get_option("--target-contact-density")->excludes(stopping.get_option("--target-number-of-epochs"));
   lefbar.get_option("--extrusion-barrier-occupancy")->excludes(barr_adv.get_option("--extrusion-barrier-bound-stp"));
   // clang-format on
+
+  std::array<std::reference_wrapper<CLI::App>, 10> option_groups{
+      io, lefbar, cgen, stopping, misc, io_adv, lef_adv, barr_adv, cgen_adv, burnin_adv};
+  std::vector<CLI::App*> option_groups_ptrs(option_groups.size());
+  std::transform(option_groups.begin(), option_groups.end(), option_groups_ptrs.begin(),
+                 [](auto& grp) { return &(grp.get()); });
+
+  return option_groups_ptrs;
 }
 
 void Cli::make_simulation_subcommand() {
@@ -492,7 +532,12 @@ void Cli::make_simulation_subcommand() {
            ->fallthrough()
            ->configurable();
   s.alias("sim");
-  add_common_options(s, this->_config);
+  auto option_group_ptrs = add_common_options(s, this->_config);
+  for (auto* og : option_group_ptrs) {
+    auto option_ptrs = og->get_options();
+    std::move(option_ptrs.begin(), option_ptrs.end(),
+              std::inserter(this->_options, this->_options.begin()));
+  }
 }
 
 void Cli::make_perturbate_subcommand() {
@@ -581,6 +626,13 @@ void Cli::make_perturbate_subcommand() {
   // clang-format on
 
   misc.get_option("--deletion-size")->excludes("--deletion-list");
+
+  auto option_group_ptrs = add_common_options(s, this->_config);
+  for (auto* og : option_group_ptrs) {
+    auto option_ptrs = og->get_options();
+    std::move(option_ptrs.begin(), option_ptrs.end(),
+              std::inserter(this->_options, this->_options.begin()));
+  }
 }
 
 void Cli::make_replay_subcommand() {
@@ -639,6 +691,12 @@ void Cli::make_replay_subcommand() {
       ->transform(CLI::Bound(1U, std::thread::hardware_concurrency()))
       ->capture_default_str();
   // clang-format on
+
+  for (auto* og : {&io, &various}) {
+    auto option_ptrs = og->get_options();
+    std::move(option_ptrs.begin(), option_ptrs.end(),
+              std::inserter(this->_options, this->_options.begin()));
+  }
 }
 
 void Cli::make_cli() {
@@ -647,10 +705,24 @@ void Cli::make_cli() {
   this->_cli.set_version_flag("-V,--version", std::string{modle::config::version::str_long()});
   this->_cli.require_subcommand(1);
   this->_cli.set_config("--config", "", "Path to MoDLE's config file (optional).", false);
+  this->_cli.formatter(std::make_shared<utils::Formatter>());
+  this->_cli.get_formatter()->column_width(30);
+
+  auto option_ptrs = this->_cli.get_options();
+  std::move(option_ptrs.begin(), option_ptrs.end(),
+            std::inserter(this->_options, this->_options.begin()));
 
   this->make_simulation_subcommand();
   this->make_perturbate_subcommand();
   this->make_replay_subcommand();
+
+  if (auto it = this->_options.find(static_cast<CLI::Option*>(nullptr));
+      it != this->_options.end()) {
+    this->_options.erase(it);
+  }
+
+  // break_long_help_lines(this->_options.begin(), this->_options.end(),
+  //                       140 - this->_cli.get_formatter()->get_column_width());
 }
 
 Cli::Cli(int argc, char** argv) : _argc(argc), _argv(argv), _exec_name(*argv) { this->make_cli(); }
@@ -670,8 +742,8 @@ const Config& Cli::parse_arguments() {
   } else {
     assert(this->_cli.get_subcommand("replay")->parsed());
     this->_subcommand = replay;
-    // The code in this branch basically tricks CLI11 into parsing a config file by creating a fake
-    // argv like: {"modle", "pert", "--config", "myconfig.toml"}
+    // The code in this branch basically tricks CLI11 into parsing a config file by creating a
+    // fake argv like: {"modle", "pert", "--config", "myconfig.toml"}
     const auto config_backup = this->_config;
     constexpr std::string_view subcmd_arg = "pert\0";
     constexpr std::string_view config_arg = "--config\0";
@@ -812,8 +884,8 @@ void Cli::validate_args() const {
            ->get_option("--num-of-tad-contacts-per-sampling-event")
            ->empty()) {
     errors.emplace_back(
-        "--num-of-tad-contacts-per-sampling-event is not allowed when the sampling strategy passed "
-        "through --contact-sampling-strategy does not involve sampling contacts from TADs.");
+        "--num-of-tad-contacts-per-sampling-event is not allowed when the sampling strategy "
+        "passed through --contact-sampling-strategy does not involve sampling contacts from TADs.");
   }
 
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)
@@ -961,8 +1033,8 @@ std::string Cli::to_json() const {
       absl::StrAppend(&buff, line, "\n");
       continue;
     }
-    // Given two subcommands named comm1 and comm2, assuming comm1 was parsed while comm2 was not,
-    // the TOML produced by CLI11 will have values for comm2 formatted as comm2.myarg1=1,
+    // Given two subcommands named comm1 and comm2, assuming comm1 was parsed while comm2 was
+    // not, the TOML produced by CLI11 will have values for comm2 formatted as comm2.myarg1=1,
     // comm2.myarg2="a" etc.
     // All we are doing here is to look for an argument name containing '.'.
     // In this way we can filter out entry corresponding to arguments for inactive subcommands
@@ -979,10 +1051,10 @@ std::string Cli::to_json() const {
     ss << toml::json_formatter{tt};
     return ss.str();
   } catch (const std::exception& e) {
-    throw std::runtime_error(fmt::format(
-        FMT_STRING(
-            "The following error occurred while converting MoDLE's config from TOML to JSON: {}"),
-        e.what()));
+    throw std::runtime_error(
+        fmt::format(FMT_STRING("The following error occurred while converting MoDLE's config "
+                               "from TOML to JSON: {}"),
+                    e.what()));
   }
 }
 

--- a/src/modle/cli.cpp
+++ b/src/modle/cli.cpp
@@ -174,7 +174,7 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "--lef-density,--lefs-per-mbp",
       c.number_of_lefs_per_mbp,
       "Loop extrusion factor (LEF) density expressed as the number of LEF per Mbp of DNA simulated.")
-      ->check(CLI::NonNegativeNumber)
+      ->check(CLI::PositiveNumber)
       ->capture_default_str();
 
   lefbar.add_option(
@@ -396,7 +396,7 @@ static void add_common_options(CLI::App& subcommand, modle::Config& config) {
       "                   --target-contact-density 2\n"
       "         Assuming chr1 is exactly 250 Mbp long, MoDLE will schedule simulation instances to yield a total of 150 000 contacts for chr1:\n"
       "         2 * (250e6 / 100e3) * (3e6 / 100e3) = 150e3.")
-      ->check(CLI::NonNegativeNumber);
+      ->check(CLI::PositiveNumber);
 
   misc.add_option(
       "--ncells",

--- a/src/modle/cli.hpp
+++ b/src/modle/cli.hpp
@@ -23,7 +23,7 @@ namespace modle {
 
 class Cli {
  public:
-  enum subcommand : u8f { help, simulate, pertubate, replay };
+  enum subcommand : u8f { help, simulate, perturbate, replay };
 
   Cli(int argc, char** argv);
   [[nodiscard]] const Config& parse_arguments();

--- a/src/modle/cli.hpp
+++ b/src/modle/cli.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <absl/container/flat_hash_set.h>
+
 #include <CLI/CLI.hpp>  // for App
 #include <string>       // for string
 
@@ -44,6 +46,7 @@ class Cli {
   Config _config;
   CLI::App _cli{};
   subcommand _subcommand{subcommand::help};
+  absl::flat_hash_set<CLI::Option*> _options{};
 
   void make_cli();
   void make_simulation_subcommand();

--- a/src/modle/main.cpp
+++ b/src/modle/main.cpp
@@ -134,7 +134,7 @@ int main(int argc, char** argv) noexcept {
       case subcommand::simulate:
         sim.run_simulate();
         break;
-      case subcommand::pertubate:
+      case subcommand::perturbate:
         if (config.compute_reference_matrix) {
           sim.run_simulate();
         }
@@ -151,8 +151,8 @@ int main(int argc, char** argv) noexcept {
                  absl::FormatDuration(absl::Now() - t0));
   } catch (const CLI::ParseError& e) {
     return cli->exit(e);  //  This takes care of formatting and printing error messages (if any)
-  } catch (const std::bad_alloc& err) {
-    spdlog::error(FMT_STRING("FAILURE! Unable to allocate enough memory: {}"), err.what());
+  } catch (const std::bad_alloc& e) {
+    spdlog::error(FMT_STRING("FAILURE! Unable to allocate enough memory: {}"), e.what());
     return 1;
   } catch (const spdlog::spdlog_ex& e) {
     fmt::print(

--- a/src/modle_tools/cli.cpp
+++ b/src/modle_tools/cli.cpp
@@ -148,14 +148,14 @@ void Cli::make_eval_subcommand() {
      "Only used when the contact matrix passed to --reference-matrix is in\n"
      "multires-cooler format.")
      ->check(CLI::PositiveNumber)
-     ->transform(utils::trim_trailing_zeros_from_decimal_digits);
+     ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit | utils::cli::AsGenomicDistance);
 
   gen.add_option(
      "-w,--diagonal-width",
      c.diagonal_width,
      "Width of the subdiagonal window to consider for comparison.")
      ->check(CLI::PositiveNumber)
-     ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+     ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit | utils::cli::AsGenomicDistance)
      ->required();
 
   gen.add_flag(
@@ -321,7 +321,7 @@ void Cli::make_noisify_subcommand() {
      c.diagonal_width,
      "Diagonal width of the input contact matrix.")
      ->check(CLI::PositiveNumber)
-     ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+     ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit)
      ->required();
 
   gen.add_option(
@@ -447,8 +447,8 @@ void Cli::make_transform_subcommand() {
       "--binary-discretization-value",
       c.discretization_val,
       "Threshold for the step function used to discretize pixels.\n"
-      "Pixels above the threshold are mapped to 1, while all the other are mapped to 0.")
-      ->check(utils::cli::IsFinite());
+      "Pixels above the threshold are mapped to 1, while all the others are mapped to 0.")
+      ->check(utils::cli::IsFinite);
 
   trans.add_option(
       "--discretization-ranges-tsv",
@@ -474,7 +474,7 @@ void Cli::make_transform_subcommand() {
       "Only used when the contact matrix passed to --reference-matrix is in\n"
       "multires-cooler format.")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits);
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit | utils::cli::AsGenomicDistance);
 
   mat.add_option(
       "-w,--diagonal-width",
@@ -482,7 +482,7 @@ void Cli::make_transform_subcommand() {
       "Width of the subdiagonal window to transform.\n"
       "Pixels outside the window are set to 0.")
       ->check(CLI::PositiveNumber)
-      ->transform(utils::trim_trailing_zeros_from_decimal_digits)
+      ->transform(utils::cli::TrimTrailingZerosFromDecimalDigit | utils::cli::AsGenomicDistance)
       ->required();
 
   gen.add_option(

--- a/src/modle_tools/include/modle_tools/modle_tools_config.hpp
+++ b/src/modle_tools/include/modle_tools/modle_tools_config.hpp
@@ -36,11 +36,11 @@ struct eval_config {
   // NOLINTNEXTLINE(cert-err58-cpp)
   inline static const utils::CliEnumMappings<enum Metric> metric_map{
       // clang-format off
-      std::make_pair("custom", Metric::custom),
-      std::make_pair("eucl_dist", Metric::eucl_dist),
-      std::make_pair("pearson", Metric::pearson),
-      std::make_pair("rmse", Metric::rmse),
-      std::make_pair("spearman", Metric::spearman)
+      {"custom", Metric::custom},
+      {"eucl_dist", Metric::eucl_dist},
+      {"pearson", Metric::pearson},
+      {"rmse", Metric::rmse},
+      {"spearman", Metric::spearman}
       // clang-format on
   };
 
@@ -116,10 +116,10 @@ struct transform_config {
   // NOLINTNEXTLINE(cert-err58-cpp)
   inline static const utils::CliEnumMappings<enum Transformation> transformation_map{
       // clang-format off
-      std::make_pair("normalize", Transformation::normalize),
-      std::make_pair("gaussian_blur", Transformation::gaussian_blur),
-      std::make_pair("difference_of_gaussians", Transformation::difference_of_gaussians),
-      std::make_pair("discretize", Transformation::discretize)
+      {"normalize", Transformation::normalize},
+      {"gaussian_blur", Transformation::gaussian_blur},
+      {"difference_of_gaussians", Transformation::difference_of_gaussians},
+      {"discretize", Transformation::discretize}
       // clang-format on
   };
 

--- a/src/modle_tools/include/modle_tools/modle_tools_config.hpp
+++ b/src/modle_tools/include/modle_tools/modle_tools_config.hpp
@@ -12,9 +12,10 @@
 #include <thread>                           // for thread
 #include <vector>                           // for vector
 
-#include "modle/bed/bed.hpp"        // for BED, BED::Dialect, BED::BED6
-#include "modle/common/common.hpp"  // for usize, bp_t, u64
-#include "modle/common/utils.hpp"   // for ConstMap
+#include "modle/bed/bed.hpp"           // for BED, BED::Dialect, BED::BED6
+#include "modle/common/cli_utils.hpp"  // for CliEnumMappings
+#include "modle/common/common.hpp"     // for usize, bp_t, u64
+#include "modle/common/utils.hpp"      // for ConstMap
 
 namespace modle::tools {
 
@@ -32,7 +33,8 @@ struct eval_config {
   enum class Metric : u8f { custom, eucl_dist, pearson, rmse, spearman };
   Metric metric{Metric::custom};
 
-  inline static const std::array<std::pair<std::string, enum Metric>, 5> metric_map{
+  // NOLINTNEXTLINE(cert-err58-cpp)
+  inline static const utils::CliEnumMappings<enum Metric> metric_map{
       // clang-format off
       std::make_pair("custom", Metric::custom),
       std::make_pair("eucl_dist", Metric::eucl_dist),
@@ -111,14 +113,15 @@ struct transform_config {
   enum class Transformation : u8f { normalize, gaussian_blur, difference_of_gaussians, discretize };
   Transformation method;
 
-  // clang-format off
-  inline static const std::array<std::pair<std::string, Transformation>, 4> transformation_map{
+  // NOLINTNEXTLINE(cert-err58-cpp)
+  inline static const utils::CliEnumMappings<enum Transformation> transformation_map{
+      // clang-format off
       std::make_pair("normalize", Transformation::normalize),
       std::make_pair("gaussian_blur", Transformation::gaussian_blur),
       std::make_pair("difference_of_gaussians", Transformation::difference_of_gaussians),
       std::make_pair("discretize", Transformation::discretize)
+      // clang-format on
   };
-  // clang-format on
 
   // Transformation settings
   std::pair<double, double> normalization_range{0.0, 1.0};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(
   test_main
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/test_main.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/units/common/cli_utils_test.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/units/common/const_map_test.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/units/contact_matrix/contact_matrix_test.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/units/interval_tree/interval_tree_test.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/units/libmodle_io/bed_parser_test.cpp

--- a/test/scripts/modle_integration_test_simple.sh
+++ b/test/scripts/modle_integration_test_simple.sh
@@ -22,9 +22,9 @@ trap 'rm -rf -- "$outdir"' EXIT
 
 # Only include chr2, chr20, chr21 and chr22
 "$modle_bin" sim -c <(grep '^chr2' "$chrom_sizes") \
-                 --extrusion-barrier-file <(xz -dc "$extr_barriers" | grep '^chr2') \
+                 -b <(xz -dc "$extr_barriers" | grep '^chr2') \
                  -o "$outdir/out" \
-                 --bin-size 20000 \
+                 -r 20000 \
                  --ncells 4 \
                  --max-burnin-epochs 5000
 

--- a/test/units/common/cli_utils_test.cpp
+++ b/test/units/common/cli_utils_test.cpp
@@ -43,4 +43,31 @@ TEST_CASE("CliEnumMappings", "[utils][short]") {
   CHECK(test_enum_map.at("a-plus-b-plus-c") == (TestEnum::a | TestEnum::b | TestEnum::c));
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("AsGenomicDistance CLI transform operator", "[utils][short]") {
+  auto fx = [&](std::string&& s) {
+    modle::utils::cli::AsGenomicDistance(s);
+    return s;
+  };
+
+  CHECK(fx("10000") == "10000");
+  CHECK(fx("10kb") == "10000");
+  CHECK(fx("10KB") == "10000");
+  CHECK(fx("10KBP") == "10000");
+  CHECK(fx("10KbP") == "10000");
+  CHECK(fx("10k") == "10000");
+
+  CHECK(fx("5.5kb") == "5500");
+  CHECK(fx("0.5kb") == "500");
+
+  CHECK(fx("1e6kb") == fx("1gbp"));
+
+  CHECK_THROWS_AS(fx("10kbpp"), CLI::ValidationError);
+  CHECK_THROWS_AS(fx("0.0001kb"), CLI::ValidationError);
+  CHECK_THROWS_AS(fx("!10gbp"), CLI::ValidationError);
+  CHECK_THROWS_AS(fx(" 10gbp"), CLI::ValidationError);
+  CHECK_THROWS_AS(fx(""), CLI::ValidationError);
+  CHECK_THROWS_AS(fx("kb"), CLI::ValidationError);
+}
+
 }  // namespace modle::test::utils

--- a/test/units/common/const_map_test.cpp
+++ b/test/units/common/const_map_test.cpp
@@ -1,0 +1,51 @@
+// Copyright (C) 2022 Roberto Rossini <roberros@uio.no>
+//
+// SPDX-License-Identifier: MIT
+
+#include "modle/common/const_map.hpp"
+
+#include <catch2/catch.hpp>
+#include <string_view>
+
+namespace modle::test::utils {
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("ConstMap Ctor", "[utils][short]") {
+  using CMap = modle::utils::ConstMap<std::string_view, int, 5>;
+  constexpr std::array<CMap::key_type, 5> keys{"1", "2", "3", "4", "5"};
+  constexpr std::array<CMap::mapped_type, 5> vals{1, 2, 3, 4, 5};
+
+  CHECK_NOTHROW(CMap{{"1", 1}, {"2", 2}, {"3", 3}, {"4", 4}, {"5", 5}});
+  CHECK_NOTHROW(CMap(keys.begin(), keys.end(), vals.begin()));
+
+  CHECK_THROWS(CMap{{"1", 1}, {"2", 2}, {"3", 3}, {"4", 4}});
+  CHECK_THROWS(CMap{{"1", 1}, {"2", 2}, {"3", 3}, {"4", 4}, {"5", 5}, {"6", 6}});
+  CHECK_THROWS(CMap(keys.begin(), keys.end() - 1, vals.begin()));
+  CHECK_THROWS(CMap(keys.begin(), keys.end() + 1, vals.begin()));
+
+  CHECK_THROWS(CMap{{"1", 1}, {"1", 2}, {"3", 3}, {"4", 4}, {"5", 5}});
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("ConstMap Accessors", "[utils][short]") {
+  using CMap = modle::utils::ConstMap<std::string_view, usize, 5>;
+  constexpr CMap map{{"1", 1}, {"2", 2}, {"3", 3}, {"4", 4}, {"5", 5}};
+  for (usize i = 1; i <= map.size(); ++i) {
+    CHECK(map.contains(std::to_string(i)));
+    CHECK(map.at(std::to_string(i)) == i);
+    const auto it = map.find(std::to_string(i));
+    CHECK(*it.first == std::to_string(i));
+    CHECK(*it.second == i);
+  }
+
+  CHECK(!map.contains("0"));
+
+  const auto& keys = map.keys();
+  const auto& values = map.values();
+  for (usize i = 0; i < keys.size(); ++i) {
+    CHECK(keys[i] == std::to_string(i + 1));
+    CHECK(values[i] == i + 1);
+  }
+}
+
+}  // namespace modle::test::utils

--- a/test/units/stats/common.hpp
+++ b/test/units/stats/common.hpp
@@ -25,6 +25,7 @@
 #include <vector>       // for vector
 
 #include "modle/common/common.hpp"  // for u32, i32, i64
+#include "modle/common/const_map.hpp"
 #include "modle/common/numeric_utils.hpp"
 #include "modle/common/random.hpp"
 

--- a/test/units/stats/tests_test.cpp
+++ b/test/units/stats/tests_test.cpp
@@ -34,7 +34,8 @@
 #include <utility>                                                // for make_pair
 #include <vector>                                                 // for vector
 
-#include "modle/common/common.hpp"         // for i64, usize
+#include "modle/common/common.hpp"  // for i64, usize
+#include "modle/common/const_map.hpp"
 #include "modle/common/numeric_utils.hpp"  // for parse_numeric_or_throw
 #include "modle/common/random.hpp"         // for PRNG_t, uniform_int_dis...
 


### PR DESCRIPTION
This PR introduces several improvements to MoDLE and helper tools CLIs.

This is a summary of the changes:
- Remove unused options
- Rename several options (see 7740f0ce610df2114378576066d4a957d64e75df)
- Improve help messages
- Hide unused//obsolete `modle_tools` subcommands
- Improve CLI appearance by providing a custom help message formatter
- Support specifying common genomic distance units (e.g. bp, kbp, mbp, gbp)