### PR TITLE
Bugfix in CLI validation

### DIFF
--- a/src/modle/cli.cpp
+++ b/src/modle/cli.cpp
@@ -879,7 +879,7 @@ void Cli::validate_args() const {
   }
 
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)
-  if (c.contact_sampling_strategy & Config::ContactSamplingStrategy::tad &&
+  if (!(c.contact_sampling_strategy & Config::ContactSamplingStrategy::tad) &&
       !subcmd->get_option_group("Advanced")
            ->get_option_group("Contact generation")
            ->get_option("--num-of-tad-contacts-per-sampling-event")
@@ -890,7 +890,7 @@ void Cli::validate_args() const {
   }
 
   // NOLINTNEXTLINE(readability-implicit-bool-conversion)
-  if (c.contact_sampling_strategy & Config::ContactSamplingStrategy::loop &&
+  if (!(c.contact_sampling_strategy & Config::ContactSamplingStrategy::loop) &&
       !subcmd->get_option_group("Advanced")
            ->get_option_group("Contact generation")
            ->get_option("--num-of-loop-contacts-per-sampling-event")


### PR DESCRIPTION
Correct validation code for the following CLI options:
- --contact-sampling-strategy
- --num-of-tad-contacts-per-sampling-event
- --num-of-loop-contacts-per-sampling-event

[no ci]