### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -15,6 +15,8 @@ on:
       - "CMakeLists.txt"
       - "Dockerfile"
       - "conanfile.py"
+    paths-ignore:
+      - "test/scripts/devel/**"
     tags:
       - 'v*.*.*'
 
@@ -28,6 +30,8 @@ on:
       - "CMakeLists.txt"
       - "Dockerfile"
       - "conanfile.py"
+    paths-ignore:
+      - "test/scripts/devel/**"
 
 # https://stackoverflow.com/a/72408109
 concurrency:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -206,7 +206,8 @@ jobs:
       - test-docker-image
 
     steps:
-      - if: |
+      - name: Collect job results
+        if: |
           needs.cache-test-datasets.result != 'success' ||
           needs.build-docker-image.result != 'success'  ||
           (needs.test-docker-image.result != 'success'  &&

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -193,3 +193,19 @@ jobs:
             modle_tools --help
             modle_tools --version
 
+
+  build-docker-image-status-check:
+    name: Status Check
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - cache-test-datasets
+      - build-docker-image
+      - test-docker-image
+
+    steps:
+      - if: |
+          needs.cache-test-datasets.result != 'success' ||
+          needs.build-docker-image.result != 'success'  ||
+          needs.test-docker-image.result != 'success'
+      - run: exit 1

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -161,3 +161,35 @@ jobs:
             GIT_TAG=${{ steps.build-args.outputs.GIT_TAG }}
             GIT_IS_DIRTY=false
             VERSION=${{ steps.build-args.outputs.VERSION }}
+
+
+  test-docker-image:
+    name: Test Docker image
+    needs: build-docker-image
+    runs-on: ubuntu-latest
+
+    container:
+      image: ghcr.io/${{ github.repository }}/modle:latest
+      options: '--entrypoint /bin/bash'
+
+      steps:
+        - name: Test modle
+          run: |
+            set -o pipefail
+
+            whereis -b modle
+            ls -lah "$(whereis -b modle | cut -d$' ' -f 2)
+
+            modle --help
+            modle --version
+
+        - name: Test modle_tools
+          run: |
+            set -o pipefail
+
+            whereis -b modle_tools
+            ls -lah "$(whereis -b modle_tools | cut -d$' ' -f 2)
+
+            modle_tools --help
+            modle_tools --version
+

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -12,11 +12,10 @@ on:
       - "external/**"
       - "src/**"
       - "test/**"
+      - "!test/scripts/devel/**"
       - "CMakeLists.txt"
       - "Dockerfile"
       - "conanfile.py"
-    paths-ignore:
-      - "test/scripts/devel/**"
     tags:
       - 'v*.*.*'
 
@@ -27,11 +26,10 @@ on:
       - "external/**"
       - "src/**"
       - "test/**"
+      - "!test/scripts/devel/**"
       - "CMakeLists.txt"
       - "Dockerfile"
       - "conanfile.py"
-    paths-ignore:
-      - "test/scripts/devel/**"
 
 # https://stackoverflow.com/a/72408109
 concurrency:
@@ -172,26 +170,26 @@ jobs:
       image: ghcr.io/${{ github.repository }}/modle:latest
       options: '--entrypoint /bin/bash'
 
-      steps:
-        - name: Test modle
-          run: |
-            set -o pipefail
+    steps:
+      - name: Test modle
+        run: |
+          set -o pipefail
 
-            whereis -b modle
-            ls -lah "$(whereis -b modle | cut -d$' ' -f 2)
+          whereis -b modle
+          ls -lah "$(whereis -b modle | cut -d$' ' -f 2)"
 
-            modle --help
-            modle --version
+          modle --help
+          modle --version
 
-        - name: Test modle_tools
-          run: |
-            set -o pipefail
+      - name: Test modle_tools
+        run: |
+          set -o pipefail
 
-            whereis -b modle_tools
-            ls -lah "$(whereis -b modle_tools | cut -d$' ' -f 2)
+          whereis -b modle_tools
+          ls -lah "$(whereis -b modle_tools | cut -d$' ' -f 2)"
 
-            modle_tools --help
-            modle_tools --version
+          modle_tools --help
+          modle_tools --version
 
 
   build-docker-image-status-check:
@@ -208,4 +206,4 @@ jobs:
           needs.cache-test-datasets.result != 'success' ||
           needs.build-docker-image.result != 'success'  ||
           needs.test-docker-image.result != 'success'
-      - run: exit 1
+        run: exit 1

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -197,7 +197,7 @@ jobs:
 
 
   build-docker-image-status-check:
-    name: Status Check
+    name: Status Check (Build Docker image)
     if: ${{ always() }}
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -165,6 +165,10 @@ jobs:
     name: Test Docker image
     needs: build-docker-image
     runs-on: ubuntu-latest
+    permissions:
+      packages: 'read'
+
+    if: github.event_name != 'pull_request'
 
     container:
       image: ghcr.io/${{ github.repository }}/modle:latest
@@ -205,5 +209,6 @@ jobs:
       - if: |
           needs.cache-test-datasets.result != 'success' ||
           needs.build-docker-image.result != 'success'  ||
-          needs.test-docker-image.result != 'success'
+          (needs.test-docker-image.result != 'success'  &&
+           needs.test-docker-image.result != 'skipped')
         run: exit 1

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -42,7 +42,9 @@ jobs:
   cache-test-datasets:
     uses: paulsengroup/modle/.github/workflows/cache-test-datasets.yml@main
 
-  build-image:
+
+  build-docker-image:
+    name: Build Docker image
     needs: cache-test-datasets
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-portable-binaries-linux.yml
+++ b/.github/workflows/build-portable-binaries-linux.yml
@@ -371,7 +371,7 @@ jobs:
 
 
   build-portable-binaries-status-check:
-    name: Status Check
+    name: Status Check (Build portable Linux binaries)
     if: ${{ always() }}
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build-portable-binaries-linux.yml
+++ b/.github/workflows/build-portable-binaries-linux.yml
@@ -360,3 +360,28 @@ jobs:
           tar -cJf "${{ steps.archive-name.outputs.name }}.tar.xz" "${{ steps.archive-name.outputs.name }}"
 
           tar -tf "${{ steps.archive-name.outputs.name }}.tar.xz"
+
+
+  build-portable-binaries-status-check:
+    name: Status Check
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - cache-test-datasets
+      - build-portable-binaries
+      - run-unit-tests
+      - run-modle-integration-tests
+      - run-modle-tools-integration-tests
+      - run-portability-test
+      - prepare-release-artifacts
+
+    steps:
+      - if: |
+          needs.cache-test-datasets.result != 'success'         ||
+          needs.build-portable-binaries.result != 'success'     ||
+          needs.run-unit-tests.result != 'success'              ||
+          needs.run-modle-integration-tests.result != 'success' ||
+          needs.run-modle-tools-integration-tests != 'success'  ||
+          needs.run-portability-test.result != 'success'        ||
+          needs.prepare-release-artifacts.result != 'success'
+      - run: exit 1

--- a/.github/workflows/build-portable-binaries-linux.yml
+++ b/.github/workflows/build-portable-binaries-linux.yml
@@ -384,12 +384,13 @@ jobs:
       - prepare-release-artifacts
 
     steps:
-      - if: |
-          needs.cache-test-datasets.result != 'success'         ||
-          needs.build-portable-binaries.result != 'success'     ||
-          needs.run-unit-tests.result != 'success'              ||
-          needs.run-modle-integration-test.result != 'success'  ||
-          needs.run-modle-tools-integration-test != 'success'   ||
-          needs.run-portability-test.result != 'success'        ||
+      - name: Collect job results
+        if: |
+          needs.cache-test-datasets.result != 'success'                ||
+          needs.build-portable-binaries.result != 'success'            ||
+          needs.run-unit-tests.result != 'success'                     ||
+          needs.run-modle-integration-test.result != 'success'         ||
+          needs.run-modle-tools-integration-test.result != 'success'   ||
+          needs.run-portability-test.result != 'success'               ||
           needs.prepare-release-artifacts.result != 'success'
         run: exit 1

--- a/.github/workflows/build-portable-binaries-linux.yml
+++ b/.github/workflows/build-portable-binaries-linux.yml
@@ -12,10 +12,9 @@ on:
       - "external/**"
       - "src/**"
       - "test/**"
+      - "!test/scripts/devel/**"
       - "CMakeLists.txt"
       - "conanfile.py"
-    paths-ignore:
-      - "test/scripts/devel/**"
     tags:
       - 'v*.*.*'
 
@@ -201,7 +200,7 @@ jobs:
         run: modle/bin/test_main --durations=yes 'exclude:*SciPy*' 'exclude:*wCorr*'
 
 
-  run-modle-integration-tests:
+  run-modle-integration-test:
     name: Run modle integration tests
     runs-on: ubuntu-latest
     needs: [build-portable-binaries, cache-test-datasets]
@@ -233,7 +232,7 @@ jobs:
         run: ./modle_integration_test.sh ${{ github.workspace }}/modle/bin/modle
 
 
-  run-modle-tools-integration-tests:
+  run-modle-tools-integration-test:
     name: Run modle_tools integration tests
     runs-on: ubuntu-latest
     needs: [build-portable-binaries, cache-test-datasets]
@@ -332,8 +331,8 @@ jobs:
     name: Prepare release artifacts
     needs:
       - run-unit-tests
-      - run-modle-integration-tests
-      - run-modle-tools-integration-tests
+      - run-modle-integration-test
+      - run-modle-tools-integration-test
       - run-portability-test
 
     runs-on: ubuntu-latest
@@ -379,8 +378,8 @@ jobs:
       - cache-test-datasets
       - build-portable-binaries
       - run-unit-tests
-      - run-modle-integration-tests
-      - run-modle-tools-integration-tests
+      - run-modle-integration-test
+      - run-modle-tools-integration-test
       - run-portability-test
       - prepare-release-artifacts
 
@@ -389,8 +388,8 @@ jobs:
           needs.cache-test-datasets.result != 'success'         ||
           needs.build-portable-binaries.result != 'success'     ||
           needs.run-unit-tests.result != 'success'              ||
-          needs.run-modle-integration-tests.result != 'success' ||
-          needs.run-modle-tools-integration-tests != 'success'  ||
+          needs.run-modle-integration-test.result != 'success'  ||
+          needs.run-modle-tools-integration-test != 'success'   ||
           needs.run-portability-test.result != 'success'        ||
           needs.prepare-release-artifacts.result != 'success'
-      - run: exit 1
+        run: exit 1

--- a/.github/workflows/build-portable-binaries-linux.yml
+++ b/.github/workflows/build-portable-binaries-linux.yml
@@ -349,7 +349,7 @@ jobs:
           version="$(basename "$GITHUB_REF")"
           version="${version#v}"
 
-          echo "name=modle-$version" >> $GITHUB_OUTPUT
+          echo "name=modle-${version}-x86_64-linux" >> $GITHUB_OUTPUT
 
       - name: Archive binaries
         run: |
@@ -360,11 +360,3 @@ jobs:
           tar -cJf "${{ steps.archive-name.outputs.name }}.tar.xz" "${{ steps.archive-name.outputs.name }}"
 
           tar -tf "${{ steps.archive-name.outputs.name }}.tar.xz"
-
-      - name: Upload Binaries
-        if: github.event_name == 'release'
-        uses: skx/github-action-publish-binaries@release-2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: "${{ steps.archive-name.outputs.name }}.tar.xz"

--- a/.github/workflows/build-portable-binaries-linux.yml
+++ b/.github/workflows/build-portable-binaries-linux.yml
@@ -349,17 +349,26 @@ jobs:
           version="$(basename "$GITHUB_REF")"
           version="${version#v}"
 
-          echo "name=modle-${version}-x86_64-linux" >> $GITHUB_OUTPUT
+          echo "prefix=modle-${version}-x86_64-linux" >> $GITHUB_OUTPUT
+          echo "name=modle-${version}-x86_64-linux.tar.xz" >> $GITHUB_OUTPUT
 
       - name: Archive binaries
         run: |
           tar -xf modle.tar.gz
           rm modle/bin/test_main
 
-          mv modle "${{ steps.archive-name.outputs.name }}"
-          tar -cJf "${{ steps.archive-name.outputs.name }}.tar.xz" "${{ steps.archive-name.outputs.name }}"
+          mv modle "${{ steps.archive-name.outputs.prefix }}"
+          tar -cJf "${{ steps.archive-name.outputs.name }}" "${{ steps.archive-name.outputs.prefix }}"
 
-          tar -tf "${{ steps.archive-name.outputs.name }}.tar.xz"
+          tar -tf "${{ steps.archive-name.outputs.name }}"
+
+      - name: Upload release archive
+        uses: actions/upload-artifact@v3
+        with:
+          name: steps.archive-name.outputs.prefix
+          if-no-files-found: error
+          retention-days: 90
+          path: steps.archive-name.outputs.name
 
 
   build-portable-binaries-status-check:

--- a/.github/workflows/build-portable-binaries-linux.yml
+++ b/.github/workflows/build-portable-binaries-linux.yml
@@ -44,7 +44,9 @@ jobs:
   cache-test-datasets:
     uses: paulsengroup/modle/.github/workflows/cache-test-datasets.yml@main
 
+
   build-portable-binaries:
+    name: Build project
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/paulsengroup/ci-docker-images/centos7-gcc-11:latest
@@ -166,7 +168,9 @@ jobs:
           retention-days: 1
           path: /tmp/modle.tar.gz
 
+
   run-unit-tests:
+    name: Run unit tests
     runs-on: ubuntu-latest
     needs: [build-portable-binaries, cache-test-datasets]
     container:
@@ -194,7 +198,9 @@ jobs:
       - name: Run unit tests
         run: modle/bin/test_main --durations=yes 'exclude:*SciPy*' 'exclude:*wCorr*'
 
+
   run-modle-integration-tests:
+    name: Run modle integration tests
     runs-on: ubuntu-latest
     needs: [build-portable-binaries, cache-test-datasets]
     container:
@@ -224,7 +230,9 @@ jobs:
         working-directory: ${{ github.workspace }}/test/scripts
         run: ./modle_integration_test.sh ${{ github.workspace }}/modle/bin/modle
 
+
   run-modle-tools-integration-tests:
+    name: Run modle_tools integration tests
     runs-on: ubuntu-latest
     needs: [build-portable-binaries, cache-test-datasets]
     container:
@@ -258,7 +266,9 @@ jobs:
         working-directory: ${{ github.workspace }}/test/scripts
         run: ./modle_tools_eval_integration_test.sh ${{ github.workspace }}/modle/bin/modle_tools
 
+
   run-portability-test:
+    name: Test portability
     runs-on: ubuntu-latest
     needs: build-portable-binaries
     strategy:
@@ -315,7 +325,9 @@ jobs:
           ./modle_tools eval --help
           ./modle_tools transform --help
 
-  publish-binaries:
+
+  prepare-release-artifacts:
+    name: Prepare release artifacts
     needs:
       - run-unit-tests
       - run-modle-integration-tests

--- a/.github/workflows/build-portable-binaries-linux.yml
+++ b/.github/workflows/build-portable-binaries-linux.yml
@@ -14,6 +14,8 @@ on:
       - "test/**"
       - "CMakeLists.txt"
       - "conanfile.py"
+    paths-ignore:
+      - "test/scripts/devel/**"
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -12,10 +12,9 @@ on:
       - "external/**"
       - "src/**"
       - "test/**"
+      - "!test/scripts/devel/**"
       - "CMakeLists.txt"
       - "conanfile.py"
-    paths-ignore:
-      - "test/scripts/devel/**"
     tags:
       - 'v*.*.*'
 
@@ -26,10 +25,9 @@ on:
       - "external/**"
       - "src/**"
       - "test/**"
+      - "!test/scripts/devel/**"
       - "CMakeLists.txt"
       - "conanfile.py"
-    paths-ignore:
-      - "test/scripts/devel/**"
 
 # https://stackoverflow.com/a/72408109
 concurrency:
@@ -224,4 +222,4 @@ jobs:
     needs: [ ci ]
     steps:
       - if: needs.ci.result != 'success'
-      - run: exit 1
+        run: exit 1

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -54,7 +54,9 @@ jobs:
   cache-test-datasets:
     uses: paulsengroup/modle/.github/workflows/cache-test-datasets.yml@main
 
-  build-project:
+
+  ci:
+    name: MacOS CI
     needs: cache-test-datasets
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -216,7 +216,7 @@ jobs:
 
 
   macos-ci-status-check:
-    name: Status Check
+    name: Status Check (MacOS CI)
     if: ${{ always() }}
     runs-on: ubuntu-latest
     needs: [ ci ]

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -215,3 +215,13 @@ jobs:
         run: |
           ${{ github.workspace }}/build/src/modle/modle --version
           ${{ github.workspace }}/build/src/modle_tools/modle_tools --version
+
+
+  macos-ci-status-check:
+    name: Status Check
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [ ci ]
+    steps:
+      - if: needs.ci.result != 'success'
+      - run: exit 1

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -14,6 +14,8 @@ on:
       - "test/**"
       - "CMakeLists.txt"
       - "conanfile.py"
+    paths-ignore:
+      - "test/scripts/devel/**"
     tags:
       - 'v*.*.*'
 
@@ -26,6 +28,8 @@ on:
       - "test/**"
       - "CMakeLists.txt"
       - "conanfile.py"
+    paths-ignore:
+      - "test/scripts/devel/**"
 
 # https://stackoverflow.com/a/72408109
 concurrency:

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -221,5 +221,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ ci ]
     steps:
-      - if: needs.ci.result != 'success'
+      - name: Collect job results
+        if: needs.ci.result != 'success'
         run: exit 1

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -441,11 +441,12 @@ jobs:
       - run-modle-tools-integration-test
 
     steps:
-      - if: |
-          needs.matrix-factory.result != 'success'              ||
-          needs.cache-test-datasets.result != 'success'         ||
-          needs.build-project.result != 'success'               ||
-          needs.run-unit-tests.result != 'success'              ||
-          needs.run-modle-integration-test.result != 'success'  ||
-          needs.run-modle-tools-integration-test != 'success'
+      - name: Collect job results
+        if: |
+          needs.matrix-factory.result != 'success'                   ||
+          needs.cache-test-datasets.result != 'success'              ||
+          needs.build-project.result != 'success'                    ||
+          needs.run-unit-tests.result != 'success'                   ||
+          needs.run-modle-integration-test.result != 'success'       ||
+          needs.run-modle-tools-integration-test.result != 'success'
         run: exit 1

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -429,7 +429,7 @@ jobs:
 
 
   ubuntu-ci-status-check:
-    name: Status Check
+    name: Status Check (Ubuntu CI)
     if: ${{ always() }}
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -51,6 +51,7 @@ defaults:
 
 jobs:
   matrix-factory:
+    name: Generate job matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-result.outputs.result }}
@@ -130,10 +131,13 @@ jobs:
 
             return { include: includes }
 
+
   cache-test-datasets:
     uses: paulsengroup/modle/.github/workflows/cache-test-datasets.yml@main
 
+
   build-project:
+    name: Build project
     needs: matrix-factory
     runs-on: ubuntu-latest
     strategy:
@@ -289,7 +293,9 @@ jobs:
       - name: Print Ccache statistics
         run: ccache -s
 
-  unit-tests:
+
+  run-unit-tests:
+    name: Run unit tests
     needs: [matrix-factory, cache-test-datasets, build-project]
     runs-on: ubuntu-latest
     strategy:
@@ -333,7 +339,9 @@ jobs:
                 --timeout 300            \
                 -j $(nproc)
 
-  modle-integration-test:
+
+  run-modle-integration-test:
+    name: Run modle integration tests
     needs: [matrix-factory, cache-test-datasets, build-project]
     runs-on: ubuntu-latest
     strategy:
@@ -371,7 +379,9 @@ jobs:
         working-directory: ${{ github.workspace }}/test/scripts
         run: ./modle_integration_test.sh ${{ github.workspace }}/bin/modle | head -n 1000
 
-  modle-tools-integration-test:
+
+  run-modle-tools-integration-test:
+    name: Run modle_tools integration tests
     needs: [matrix-factory, cache-test-datasets, build-project]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -428,3 +428,26 @@ jobs:
         working-directory: ${{ github.workspace }}/test/scripts
         run: |
           ./modle_tools_eval_integration_test.sh ${{ github.workspace }}/bin/modle_tools | head -n 1000
+
+
+  ubuntu-ci-status-check:
+    name: Status Check
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs:
+      - matrix-factory
+      - cache-test-datasets
+      - build-project
+      - run-unit-tests
+      - run-modle-integration-tests
+      - run-modle-tools-integration-tests
+
+    steps:
+      - if: |
+          needs.matrix-factory.result != 'success'              ||
+          needs.cache-test-datasets.result != 'success'         ||
+          needs.build-project.result != 'success'               ||
+          needs.run-unit-tests.result != 'success'              ||
+          needs.run-modle-integration-tests.result != 'success' ||
+          needs.run-modle-tools-integration-tests != 'success'
+      - run: exit 1

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -14,6 +14,8 @@ on:
       - "test/**"
       - "CMakeLists.txt"
       - "conanfile.py"
+    paths-ignore:
+      - "test/scripts/devel/**"
     tags:
       - 'v*.*.*'
 
@@ -26,6 +28,8 @@ on:
       - "test/**"
       - "CMakeLists.txt"
       - "conanfile.py"
+    paths-ignore:
+      - "test/scripts/devel/**"
 
 # https://stackoverflow.com/a/72408109
 concurrency:

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -12,10 +12,9 @@ on:
       - "external/**"
       - "src/**"
       - "test/**"
+      - "!test/scripts/devel/**"
       - "CMakeLists.txt"
       - "conanfile.py"
-    paths-ignore:
-      - "test/scripts/devel/**"
     tags:
       - 'v*.*.*'
 
@@ -26,10 +25,9 @@ on:
       - "external/**"
       - "src/**"
       - "test/**"
+      - "!test/scripts/devel/**"
       - "CMakeLists.txt"
       - "conanfile.py"
-    paths-ignore:
-      - "test/scripts/devel/**"
 
 # https://stackoverflow.com/a/72408109
 concurrency:
@@ -439,8 +437,8 @@ jobs:
       - cache-test-datasets
       - build-project
       - run-unit-tests
-      - run-modle-integration-tests
-      - run-modle-tools-integration-tests
+      - run-modle-integration-test
+      - run-modle-tools-integration-test
 
     steps:
       - if: |
@@ -448,6 +446,6 @@ jobs:
           needs.cache-test-datasets.result != 'success'         ||
           needs.build-project.result != 'success'               ||
           needs.run-unit-tests.result != 'success'              ||
-          needs.run-modle-integration-tests.result != 'success' ||
-          needs.run-modle-tools-integration-tests != 'success'
-      - run: exit 1
+          needs.run-modle-integration-test.result != 'success'  ||
+          needs.run-modle-tools-integration-test != 'success'
+        run: exit 1


### PR DESCRIPTION
- Minor formatting/style changes
- Add "test/scripts/devel/**" to path-ignore
- Add test step to build-docker-image.yml
  This is mostly useful to ensure modle* binaries can be looked up in  `$PATH` and that there
  are no permission/link errors
- Remove "Upload Binaries" steps from `.github/workflows/build-portable-binaries-linux.yml`.
  We are not going to release very often, so there's no need to automate/complicate release
  artifact upload
- Add a status check job at the end of every workflow