### PR TITLE
Improve BED and .chrom.sizes parser

### DIFF
--- a/src/common/include/modle/common/utils.hpp
+++ b/src/common/include/modle/common/utils.hpp
@@ -128,7 +128,7 @@ class LockRangeShared {
   LockRangeShared& operator=(LockRangeShared&& other) noexcept = delete;
 };
 
-[[nodiscard]] constexpr std::string_view strip_quotes(std::string_view s) noexcept;
+[[nodiscard]] constexpr std::string_view strip_quote_pairs(std::string_view s) noexcept;
 
 }  // namespace modle::utils
 

--- a/src/common/include/modle/common/utils.hpp
+++ b/src/common/include/modle/common/utils.hpp
@@ -128,6 +128,8 @@ class LockRangeShared {
   LockRangeShared& operator=(LockRangeShared&& other) noexcept = delete;
 };
 
+[[nodiscard]] constexpr std::string_view strip_quotes(std::string_view s) noexcept;
+
 }  // namespace modle::utils
 
 #include "../../../utils_impl.hpp"  // IWYU pragma: export

--- a/src/common/utils_impl.hpp
+++ b/src/common/utils_impl.hpp
@@ -205,16 +205,15 @@ LockRangeShared<MutexT>::~LockRangeShared() noexcept {
   std::for_each(this->_mutexes.begin(), this->_mutexes.end(), [](auto &m) { m.unlock_shared(); });
 }
 
-constexpr std::string_view strip_quotes(std::string_view s) noexcept {
-  assert(!s.empty());
-  if (s.front() == '\'' || s.front() == '"') {
-    s = s.substr(1);
+constexpr std::string_view strip_quote_pairs(std::string_view s) noexcept {
+  if (s.size() < 2) {
+    return s;
   }
-  assert(!s.empty());
-  if (s.back() == '\'' || s.back() == '"') {
-    s = s.substr(0, s.size() - 1);
+  const auto str_begins_with_quote = s.front() == '\'' || s.front() == '"';
+  const auto str_ends_with_quote = s.back() == '\'' || s.back() == '"';
+  if (str_begins_with_quote && str_ends_with_quote) {
+    return s.substr(1, s.size() - 2);
   }
-  assert(!s.empty());
   return s;
 }
 }  // namespace modle::utils

--- a/src/common/utils_impl.hpp
+++ b/src/common/utils_impl.hpp
@@ -204,6 +204,19 @@ template <class MutexT>
 LockRangeShared<MutexT>::~LockRangeShared() noexcept {
   std::for_each(this->_mutexes.begin(), this->_mutexes.end(), [](auto &m) { m.unlock_shared(); });
 }
+
+constexpr std::string_view strip_quotes(std::string_view s) noexcept {
+  assert(!s.empty());
+  if (s.front() == '\'' || s.front() == '"') {
+    s = s.substr(1);
+  }
+  assert(!s.empty());
+  if (s.back() == '\'' || s.back() == '"') {
+    s = s.substr(0, s.size() - 1);
+  }
+  assert(!s.empty());
+  return s;
+}
 }  // namespace modle::utils
 
 // IWYU pragma: private, include "modle/utils.hpp"

--- a/src/libmodle_io/bed.cpp
+++ b/src/libmodle_io/bed.cpp
@@ -42,15 +42,16 @@ bool RGB::operator==(const modle::bed::RGB& other) const noexcept {
 bool RGB::operator!=(const modle::bed::RGB& other) const noexcept { return !(*this == other); }
 
 void BED::parse_strand_or_throw(const std::vector<std::string_view>& toks, u8 idx, char& field) {
-  const auto match = bed_strand_encoding.find(utils::strip_quotes(toks[idx]));
+  const auto tok = utils::strip_quote_pairs(toks[idx]);
+  const auto match = bed_strand_encoding.find(tok);
   if (match == bed_strand_encoding.end()) {
-    throw std::runtime_error(fmt::format(FMT_STRING("unrecognized strand \"{}\""), toks[idx]));
+    throw std::runtime_error(fmt::format(FMT_STRING("unrecognized strand \"{}\""), tok));
   }
   field = *match.second;
 }
 
 void BED::parse_rgb_or_throw(const std::vector<std::string_view>& toks, u8 idx, RGB& field) {
-  const auto tok = utils::strip_quotes(toks[idx]);
+  const auto tok = utils::strip_quote_pairs(toks[idx]);
   if (tok == "0") {
     field = RGB{0, 0, 0};
     return;
@@ -125,7 +126,7 @@ void BED::validate_record(const std::vector<std::string_view>& toks, const Diale
 }
 
 void BED::parse_chrom(const std::vector<std::string_view>& toks) {
-  this->chrom = utils::strip_quotes(toks[BED_CHROM_IDX]);
+  this->chrom = utils::strip_quote_pairs(toks[BED_CHROM_IDX]);
 }
 
 void BED::parse_chrom_start(const std::vector<std::string_view>& toks) {
@@ -145,7 +146,7 @@ bool BED::parse_chrom_end(const std::vector<std::string_view>& toks) {
 
 bool BED::parse_name(const std::vector<std::string_view>& toks) {
   assert(this->_standard >= BED4);
-  this->name = utils::strip_quotes(toks[BED_NAME_IDX]);
+  this->name = utils::strip_quote_pairs(toks[BED_NAME_IDX]);
   return this->_standard == BED4;
 }
 

--- a/src/libmodle_io/chrom_sizes.cpp
+++ b/src/libmodle_io/chrom_sizes.cpp
@@ -17,6 +17,7 @@
 #include <vector>       // for vector
 
 #include "modle/bed/bed.hpp"  // for BED
+#include "modle/common/utils.hpp"
 
 namespace modle::chrom_sizes {
 
@@ -41,14 +42,15 @@ std::vector<bed::BED> Parser::parse_all(char sep) {
       }
       DISABLE_WARNING_PUSH
       DISABLE_WARNING_NULL_DEREF
-      if (const auto chrom_name = *splitter.begin(); chrom_names.contains(chrom_name)) {
+      const auto chrom_name = utils::strip_quotes(*splitter.begin());
+      if (chrom_names.contains(chrom_name)) {
         throw std::runtime_error(
             fmt::format(FMT_STRING("found multiple records for chrom \"{}\""), chrom_name));
       }
       DISABLE_WARNING_POP
       chrom_sizes.emplace_back(
-          fmt::format(FMT_COMPILE("{}\t0\t{}"), *splitter.begin(), *std::next(splitter.begin())),
-          id++, bed::BED::BED3);
+          fmt::format(FMT_COMPILE("{}\t0\t{}"), chrom_name, *std::next(splitter.begin())), id++,
+          bed::BED::BED3);
     } catch (const std::runtime_error& e) {
       throw std::runtime_error(
           fmt::format(FMT_STRING("encountered a malformed record at line {} of file \"{}\": {}.\n "

--- a/src/libmodle_io/chrom_sizes.cpp
+++ b/src/libmodle_io/chrom_sizes.cpp
@@ -42,7 +42,7 @@ std::vector<bed::BED> Parser::parse_all(char sep) {
       }
       DISABLE_WARNING_PUSH
       DISABLE_WARNING_NULL_DEREF
-      const auto chrom_name = utils::strip_quotes(*splitter.begin());
+      const auto chrom_name = utils::strip_quote_pairs(*splitter.begin());
       if (chrom_names.contains(chrom_name)) {
         throw std::runtime_error(
             fmt::format(FMT_STRING("found multiple records for chrom \"{}\""), chrom_name));

--- a/src/libmodle_io/include/bed/modle/bed/bed.hpp
+++ b/src/libmodle_io/include/bed/modle/bed/bed.hpp
@@ -31,6 +31,8 @@ struct RGB {
   u8 g;
   u8 b;
 
+  bool operator==(const RGB& other) const noexcept;
+  bool operator!=(const RGB& other) const noexcept;
   [[nodiscard]] std::string to_string() const;
 };
 

--- a/test/units/libmodle_io/bed_parser_test.cpp
+++ b/test/units/libmodle_io/bed_parser_test.cpp
@@ -100,6 +100,8 @@ TEST_CASE("BED: strip quotes", "[parsers][BED][io][short]") {
     CHECK(record.thick_start == 0);
     CHECK(record.thick_end == 1);
     CHECK(*record.rgb == RGB{});
+
+    CHECK(bed::BED("\"chr1\t0\t1").chrom == "\"chr1");
   }
 
   SECTION("invalid") {

--- a/test/units/libmodle_io/bed_parser_test.cpp
+++ b/test/units/libmodle_io/bed_parser_test.cpp
@@ -77,6 +77,38 @@ TEST_CASE("BED Parser simple", "[parsers][BED][io][short]") {
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+TEST_CASE("BED: strip quotes", "[parsers][BED][io][short]") {
+  SECTION("valid") {
+    constexpr std::string_view line{
+        "chr1\t"
+        "0\t"
+        "10\t"
+        "\"name\"\t"
+        "0.0\t"
+        "\"+\"\t"
+        "0\t"
+        "1\t"
+        "\"0,0,0\""};
+
+    const bed::BED record(line);
+    CHECK(record.chrom == "chr1");
+    CHECK(record.chrom_start == 0);
+    CHECK(record.chrom_end == 10);
+    CHECK(record.name == "name");
+    CHECK(record.score == 0.0);
+    CHECK(record.strand == '+');
+    CHECK(record.thick_start == 0);
+    CHECK(record.thick_end == 1);
+    CHECK(*record.rgb == RGB{});
+  }
+
+  SECTION("invalid") {
+    CHECK_THROWS(bed::BED("chr1\t\"0\"\t1"));
+    CHECK_THROWS(bed::BED("chr1\t0\t1\t.\t\"0.0\""));
+  }
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("BED Parser simple: BED6 -> BED3", "[parsers][BED][io][short]") {
   const auto bed_file = data_dir() / "genomic_intervals" / "intervals.bed6.xz";
   auto p = bed::Parser(bed_file, BED::BED3);


### PR DESCRIPTION
Extend parsers to support reading BED/TSV files with string fields enclosed by single or double quotes.