### PR TITLE
Improve text file parsing

### DIFF
--- a/src/libmodle/internal/genome.cpp
+++ b/src/libmodle/internal/genome.cpp
@@ -346,6 +346,7 @@ std::vector<std::shared_ptr<const Chromosome>> Genome::import_chromosomes(
   std::vector<std::shared_ptr<const Chromosome>> buffer{};
   for (auto&& record : chrom_sizes::Parser(path_to_chrom_sizes).parse_all()) {
     if (auto it = chrom_names.find(record.chrom); it != chrom_names.end()) {
+      assert(record.size() != 0);
       throw std::runtime_error(fmt::format(
           FMT_STRING(
               "Found duplicate entry for {} at line {} of file {}! First entry was at line {}"),

--- a/src/libmodle_io/bed.cpp
+++ b/src/libmodle_io/bed.cpp
@@ -6,6 +6,7 @@
 
 #include "modle/bed/bed.hpp"
 
+#include <absl/strings/ascii.h>
 #include <absl/strings/match.h>      // for StrContains
 #include <absl/strings/str_join.h>   // for StrJoin
 #include <absl/strings/str_split.h>  // for StrSplit, Splitter, SplitIterator
@@ -247,7 +248,8 @@ BED::BED(BED::Dialect d) : _standard(d) {}
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 BED::BED(std::string_view record, usize id_, BED::Dialect bed_standard, bool validate) : _id(id_) {
   std::vector<std::string_view> toks;
-  for (std::string_view tok : absl::StrSplit(record, absl::ByAnyChar("\t "))) {
+  for (std::string_view tok :
+       absl::StrSplit(absl::StripTrailingAsciiWhitespace(record), absl::ByAnyChar("\t "))) {
     if (!tok.empty()) {
       toks.push_back(tok);
     }

--- a/src/libmodle_io/chrom_sizes.cpp
+++ b/src/libmodle_io/chrom_sizes.cpp
@@ -31,16 +31,17 @@ std::vector<bed::BED> Parser::parse_all(char sep) {
   std::vector<bed::BED> chrom_sizes;
 
   for (usize i = 1UL, id = 0; this->_reader.getline(buff); ++i) {
+    buff = absl::StripTrailingAsciiWhitespace(buff);
     if (buff.empty()) {
       continue;
     }
 
-    const auto splitter = absl::StrSplit(absl::StripTrailingAsciiWhitespace(buff), sep);
+    const auto splitter = absl::StrSplit(buff, sep);
     const auto num_toks = std::distance(splitter.begin(), splitter.end());
     try {
       if (num_toks != 2) {
         throw std::runtime_error(
-            fmt::format(FMT_STRING("expected exactly 2 tokens, found {}: \"{}\""), num_toks, buff));
+            fmt::format(FMT_STRING("expected exactly 2 fields, found {}: \"{}\""), num_toks, buff));
       }
       DISABLE_WARNING_PUSH
       DISABLE_WARNING_NULL_DEREF

--- a/src/libmodle_io/chrom_sizes.cpp
+++ b/src/libmodle_io/chrom_sizes.cpp
@@ -38,9 +38,9 @@ std::vector<bed::BED> Parser::parse_all(char sep) {
     const auto splitter = absl::StrSplit(absl::StripTrailingAsciiWhitespace(buff), sep);
     const auto num_toks = std::distance(splitter.begin(), splitter.end());
     try {
-      if (num_toks < 2) {
+      if (num_toks != 2) {
         throw std::runtime_error(
-            fmt::format(FMT_STRING("expected 2 or more tokens, got {}: \"{}\""), num_toks, buff));
+            fmt::format(FMT_STRING("expected exactly 2 tokens, found {}: \"{}\""), num_toks, buff));
       }
       DISABLE_WARNING_PUSH
       DISABLE_WARNING_NULL_DEREF
@@ -55,9 +55,9 @@ std::vector<bed::BED> Parser::parse_all(char sep) {
           bed::BED::BED3);
     } catch (const std::runtime_error& e) {
       throw std::runtime_error(
-          fmt::format(FMT_STRING("encountered a malformed record at line {} of file \"{}\": {}.\n "
+          fmt::format(FMT_STRING("encountered a malformed record at line {} of file {}: {}.\n "
                                  "Line that triggered the error:\n\"{}\""),
-                      i, this->_reader.path_string(), e.what(), buff.data()));
+                      i, this->_reader.path(), e.what(), buff.data()));
     }
   }
   return chrom_sizes;

--- a/src/libmodle_io/chrom_sizes.cpp
+++ b/src/libmodle_io/chrom_sizes.cpp
@@ -5,9 +5,11 @@
 #include "modle/chrom_sizes/chrom_sizes.hpp"  // for Parser
 
 #include <absl/container/flat_hash_set.h>  // for flat_hash_set
-#include <absl/strings/str_split.h>        // for StrSplit, Splitter
+#include <absl/strings/ascii.h>
+#include <absl/strings/str_split.h>  // for StrSplit, Splitter
 #include <fmt/compile.h>
 #include <fmt/format.h>  // for format, FMT_COMPILE_STRING, FMT_STRING...
+#include <fmt/std.h>
 
 #include <cassert>      // for assert
 #include <filesystem>   // for filesystem::path
@@ -33,7 +35,7 @@ std::vector<bed::BED> Parser::parse_all(char sep) {
       continue;
     }
 
-    const auto splitter = absl::StrSplit(buff, sep);
+    const auto splitter = absl::StrSplit(absl::StripTrailingAsciiWhitespace(buff), sep);
     const auto num_toks = std::distance(splitter.begin(), splitter.end());
     try {
       if (num_toks < 2) {

--- a/src/libmodle_io/chrom_sizes.cpp
+++ b/src/libmodle_io/chrom_sizes.cpp
@@ -45,11 +45,17 @@ std::vector<bed::BED> Parser::parse_all(char sep) {
       DISABLE_WARNING_PUSH
       DISABLE_WARNING_NULL_DEREF
       const auto chrom_name = utils::strip_quote_pairs(*splitter.begin());
+      const auto chrom_size = *std::next(splitter.begin());
+      DISABLE_WARNING_POP
       if (chrom_names.contains(chrom_name)) {
         throw std::runtime_error(
             fmt::format(FMT_STRING("found multiple records for chrom \"{}\""), chrom_name));
       }
-      DISABLE_WARNING_POP
+
+      if (chrom_size == "0") {
+        throw std::runtime_error(
+            fmt::format(FMT_STRING("chrom \"{}\" has a length of 0bp"), chrom_name));
+      }
       chrom_sizes.emplace_back(
           fmt::format(FMT_COMPILE("{}\t0\t{}"), chrom_name, *std::next(splitter.begin())), id++,
           bed::BED::BED3);


### PR DESCRIPTION
- Properly deal with `CRLF` when reading BED/.chrom.sizes files created on Windows
- Improve validation of `.chrom.sizes` files